### PR TITLE
Set product name in .tractusx

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -17,4 +17,5 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
+product: "Policy Hub"
 leadingRepository: "https://github.com/eclipse-tractusx/policy-hub"


### PR DESCRIPTION
The trg https://eclipse-tractusx.github.io/docs/release/trg-2/trg-2-5 asks for a product name.

This product name is used in the overview dashboard https://eclipse-tractusx.github.io/sig-release/ were the policy-hub entry is visible as empty (see the top first entry without a name but a broken heart.