### PR TITLE
feat(helm-chart): use templates for unique resource names

### DIFF
--- a/charts/policy-hub/templates/_helpers.tpl
+++ b/charts/policy-hub/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "chart.name" -}}
+{{- define "phub.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "chart.fullname" -}}
+{{- define "phub.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,16 +26,16 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "chart.chart" -}}
+{{- define "phub.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "chart.labels" -}}
-helm.sh/chart: {{ include "chart.chart" . }}
-{{ include "chart.selectorLabels" . }}
+{{- define "phub.labels" -}}
+helm.sh/chart: {{ include "phub.chart" . }}
+{{ include "phub.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -45,17 +45,17 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "chart.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "chart.name" . }}
+{{- define "phub.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "phub.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
 Create the name of the service account to use
 */}}
-{{- define "chart.serviceAccountName" -}}
+{{- define "phub.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "chart.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "phub.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/policy-hub/templates/deployment-hub.yaml
+++ b/charts/policy-hub/templates/deployment-hub.yaml
@@ -20,21 +20,24 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.policyhub.name }}
+  name: {{ include "phub.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "phub.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   selector:
     matchLabels:
-      app: {{ .Values.policyhub.name }}
+      {{- include "phub.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Values.policyhub.name }}
+        {{- include "phub.selectorLabels" . | nindent 8 }}
     spec:
       containers:
-      - name: {{ .Values.policyhub.name }}
+      - name: {{ .Chart.Name }}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/policy-hub/templates/ingress.yaml
+++ b/charts/policy-hub/templates/ingress.yaml
@@ -18,7 +18,7 @@
 */}}
 
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := .Values.ingress.name -}}
+{{- $fullName := include "phub.fullname" . -}}
 {{- $svcPort := .Values.portService -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -34,9 +34,9 @@ apiVersion: extensions/v1beta1
 {{- end }}
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-{{ $fullName }}
+  name: {{ $fullName }}
   labels:
-    {{- include "chart.labels" . | nindent 4 }}
+    {{- include "phub.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -68,11 +68,11 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ .backend.service }}
+                name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ .backend.service }}
+              serviceName: {{ $fullName }}
               servicePort: {{ .backend.port }}
               {{- end }}
           {{- end }}

--- a/charts/policy-hub/templates/job-policy-hub-migrations.yaml
+++ b/charts/policy-hub/templates/job-policy-hub-migrations.yaml
@@ -28,11 +28,12 @@ metadata:
 spec:
   template:
     metadata:
-      name: {{ .Values.policyhubmigrations.name }}
+      labels:
+        {{- include "phub.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       containers:
-      - name: {{ .Values.policyhubmigrations.name }}
+      - name: {{ include "phub.fullname" . }}-migrations
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/charts/policy-hub/templates/job-policy-hub-migrations.yaml
+++ b/charts/policy-hub/templates/job-policy-hub-migrations.yaml
@@ -20,7 +20,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ .Release.Name }}-{{ .Values.policyhubmigrations.name }}
+  name: {{ include "phub.fullname" . }}-migrations
   annotations:
     "batch.kubernetes.io/job-tracking": "true"
     "helm.sh/hook": post-install,post-upgrade

--- a/charts/policy-hub/templates/service-hub.yaml
+++ b/charts/policy-hub/templates/service-hub.yaml
@@ -20,11 +20,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Release.Name }}-{{ .Values.policyhub.name }}"
+  name: {{ include "phub.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "phub.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   ports:
   - port: {{ .Values.portService }}
     targetPort: {{ .Values.portContainer }}
   selector:
-    app: {{ .Values.policyhub.name }}
+    {{- include "phub.selectorLabels" . | nindent 4 }}

--- a/charts/policy-hub/values.yaml
+++ b/charts/policy-hub/values.yaml
@@ -17,8 +17,6 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-name: "policy-hub"
-
 # -- Provide centralidp base address (CX IAM), without trailing '/auth'.
 centralidpAddress: "https://centralidp.example.org"
 
@@ -47,7 +45,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 dotnetEnvironment: "Production"
 dbConnection:
@@ -76,7 +73,6 @@ healthChecks:
     path: "/ready"
 
 policyhub:
-  name: "policy-hub-service"
   image: "tractusx/policy-hub-service:0.1.0-rc.1"
   # -- We recommend not to specify default resource limits and to leave this as a conscious choice for the user.
   # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.
@@ -98,7 +94,6 @@ policyhub:
   swaggerEnabled: false
 
 policyhubmigrations:
-  name: "policy-hub-migrations"
   image: "tractusx/policy-hub-migrations:0.1.0-rc.1"
   # -- We recommend not to specify default resource limits and to leave this as a conscious choice for the user.
   # If you do want to specify resource limits, uncomment the following lines and adjust them as necessary.

--- a/consortia/environments/values-beta.yaml
+++ b/consortia/environments/values-beta.yaml
@@ -38,7 +38,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 
 policyhub:

--- a/consortia/environments/values-dev.yaml
+++ b/consortia/environments/values-dev.yaml
@@ -38,7 +38,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 
 keycloak:

--- a/consortia/environments/values-int.yaml
+++ b/consortia/environments/values-int.yaml
@@ -38,7 +38,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 
 keycloak:

--- a/consortia/environments/values-pen.yaml
+++ b/consortia/environments/values-pen.yaml
@@ -38,7 +38,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 
 policyhub:

--- a/consortia/environments/values-rc.yaml
+++ b/consortia/environments/values-rc.yaml
@@ -38,7 +38,6 @@ ingress:
         - path: "/api/policy-hub"
           pathType: "Prefix"
           backend:
-            service: "policy-hub-service"
             port: 8080
 
 policyhub:


### PR DESCRIPTION
## Description

- use templates for unique resource names
- fix wrong service name in ingress

## Why

improve helm chart

## Issue

follow up to https://github.com/eclipse-tractusx/policy-hub/pull/11

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/developer/Technical-Documentation/Dev-Process/How-to-contribute.md#commit-and-pr-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally