### PR TITLE
fix(helm-chart): don't change postgres secret at helm upgrade

### DIFF
--- a/charts/policy-hub/templates/_helpers.tpl
+++ b/charts/policy-hub/templates/_helpers.tpl
@@ -31,6 +31,13 @@ Create chart name and version as used by the chart label.
 {{- end }}
 
 {{/*
+Define secret name of postgres dependency.
+*/}}
+{{- define "phub.postgresSecretName" -}}
+{{- printf "%s-%s" .Release.Name "phub-postgres" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "phub.labels" -}}

--- a/charts/policy-hub/templates/deployment-hub.yaml
+++ b/charts/policy-hub/templates/deployment-hub.yaml
@@ -54,7 +54,7 @@ spec:
         - name: "POLICY_HUB_PASSWORD"
           valueFrom:
             secretKeyRef:
-              name: "{{ .Release.Name }}-phub-postgres"
+              name: "{{ template "phub.postgresSecretName" . }}"
               key: "password"
         - name: "CONNECTIONSTRINGS__POLICYHUBDB"
           value: "Server={{ template "postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"

--- a/charts/policy-hub/templates/job-policy-hub-migrations.yaml
+++ b/charts/policy-hub/templates/job-policy-hub-migrations.yaml
@@ -50,7 +50,7 @@ spec:
           - name: "POLICY_HUB_PASSWORD"
             valueFrom:
               secretKeyRef:
-                name: "{{ .Release.Name }}-phub-postgres"
+                name: "{{ template "phub.postgresSecretName" . }}"
                 key: "password"
           - name: "CONNECTIONSTRINGS__POLICYHUBDB"
             value: "Server={{ template "postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"

--- a/charts/policy-hub/templates/secret-postgres.yaml
+++ b/charts/policy-hub/templates/secret-postgres.yaml
@@ -1,13 +1,32 @@
+{{- /*
+* Copyright (c) 2024 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Apache License, Version 2.0 which is available at
+* https://www.apache.org/licenses/LICENSE-2.0.
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+* License for the specific language governing permissions and limitations
+* under the License.
+*
+* SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.postgresql.enabled -}}
+{{- $secretName := include "phub.postgresSecretName" . -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-phub-postgres
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 # use lookup function to check if secret exists
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.postgresql.auth.existingSecret) }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace $secretName) }}
 {{ if $secret -}}
 data:
   # if secret exists, use value provided from values file (to cover update scenario) or existing value from secret

--- a/charts/policy-hub/values.yaml
+++ b/charts/policy-hub/values.yaml
@@ -125,6 +125,7 @@ postgresql:
     # -- Database name.
     database: policy-hub
     # -- Secret containing the passwords for root usernames postgres and non-root username hub.
+    # Should not be changed without changing the "phub-postgresSecretName" template as well.
     existingSecret: "{{ .Release.Name }}-phub-postgres"
   architecture: replication
   audit:


### PR DESCRIPTION
## Description

don't change postgres secret from dependency at helm upgrade
add file header

## Why

https://github.com/eclipse-tractusx/policy-hub/issues/32

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes
- [x] I have successfully tested my changes