### PR TITLE
chore: push git tag after chart release

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -57,7 +57,14 @@ jobs:
           helm dependency update
 
       - name: Run chart-releaser
+        id: chart-release
         uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: "true"
+
+      - name: Push git tag for release workflow to be triggered
+        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # v1.7.2
+        with:
+          tag: v${{ steps.chart-release.outputs.chart_version }}
+        if: ${{ steps.chart-release.outputs.changed_charts }}


### PR DESCRIPTION
## Description

push git tag after chart release for release workflow to be triggered

## Why

improve on release automation

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes