### PR TITLE
chore(dast-owasp-zap): remove summary and set retention-days

### DIFF
--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -124,15 +124,10 @@ jobs:
           
           echo "... done."
 
-      - name: Add Summary
-        if: success() || failure()
-        run: |
-          echo "Publishing Job summary... "
-          cat report_md.md >> $GITHUB_STEP_SUMMARY
-
       - name: Upload HTML report
         if: success() || failure()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: ZAP scan report
           path: ./report_html.html
+          retention-days: 1


### PR DESCRIPTION
## Description

remove summary and set retention-days for OWASP ZAP scan
[example run](https://github.com/eclipse-tractusx/policy-hub/actions/runs/7919313113)

## Why

feedback from sec team

## Issue

https://github.com/eclipse-tractusx/policy-hub/issues/29

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes