### PR TITLE
feat(helm-chart): define templates for db hostname uniquely

### DIFF
--- a/charts/policy-hub/templates/_helpers.tpl
+++ b/charts/policy-hub/templates/_helpers.tpl
@@ -72,19 +72,19 @@ Create the name of the service account to use
 Determine database hostname for subchart
 */}}
 
-{{- define "postgresql.primary.fullname" -}}
+{{- define "phub.postgresql.primary.fullname" -}}
 {{- if eq .Values.postgresql.architecture "replication" }}
-{{- printf "%s-primary" (include "chart-name-postgresql-dependency" .) | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-primary" (include "phub.chart.name.postgresql.dependency" .) | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-    {{- include "chart-name-postgresql-dependency" . -}}
+    {{- include "phub.chart.name.postgresql.dependency" . -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "postgresql.readReplica.fullname" -}}
-{{- printf "%s-read" (include "chart-name-postgresql-dependency" .) | trunc 63 | trimSuffix "-" -}}
+{{- define "phub.postgresql.readReplica.fullname" -}}
+{{- printf "%s-read" (include "phub.chart.name.postgresql.dependency" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "chart-name-postgresql-dependency" -}}
+{{- define "phub.chart.name.postgresql.dependency" -}}
 {{- if .Values.postgresql.fullnameOverride -}}
 {{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}

--- a/charts/policy-hub/templates/deployment-hub.yaml
+++ b/charts/policy-hub/templates/deployment-hub.yaml
@@ -57,7 +57,7 @@ spec:
               name: "{{ template "phub.postgresSecretName" . }}"
               key: "password"
         - name: "CONNECTIONSTRINGS__POLICYHUBDB"
-          value: "Server={{ template "postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"
+          value: "Server={{ template "phub.postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"
         {{- end }}
         {{- if not .Values.postgresql.enabled }}
         - name: "POLICY_HUB_PASSWORD"

--- a/charts/policy-hub/templates/job-policy-hub-migrations.yaml
+++ b/charts/policy-hub/templates/job-policy-hub-migrations.yaml
@@ -53,7 +53,7 @@ spec:
                 name: "{{ template "phub.postgresSecretName" . }}"
                 key: "password"
           - name: "CONNECTIONSTRINGS__POLICYHUBDB"
-            value: "Server={{ template "postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"
+            value: "Server={{ template "phub.postgresql.primary.fullname" . }};Database={{ .Values.postgresql.auth.database }};Port={{ .Values.postgresql.auth.port }};User Id={{ .Values.postgresql.auth.username }};Password=$(POLICY_HUB_PASSWORD);Ssl Mode={{ .Values.dbConnection.sslMode }};"
           {{- end }}
           {{- if not .Values.postgresql.enabled }}
           - name: "POLICY_HUB_PASSWORD"


### PR DESCRIPTION
## Description

helm-chart: define templates for db hostname uniquely

## Why

improve helm-chart for umbrella use case

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes