### PR TITLE
chore(ci): fix dash tool file name in workflow

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -57,7 +57,7 @@ jobs:
         run: dotnet list src package --include-transitive --interactive | grep ">" | grep -Pv "\s(Org.Eclipse.TractusX|Microsoft|NuGet|System|runtime|docker|Docker|NETStandard)" | sed -E -e "s/\s+> ([a-zA-Z\.\-]+).+\s([0-9]+\.[0-9]+\.[0-9]+)\s*/nuget\/nuget\/\-\/\1\/\2/g" | awk '!seen[$0]++' > PACKAGES
 
       - name: Generate Dependencies file
-        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.0.2.jar PACKAGES -project automotive.tractusx -summary DEPENDENCIES || true
+        run: java -jar ./scripts/download/org.eclipse.dash.licenses-1.1.1-20240213.065029-71.jar PACKAGES -project automotive.tractusx -summary DEPENDENCIES || true
 
       - name: Check if dependencies were changed
         id: dependencies-changed


### PR DESCRIPTION
## Description

A new version of the dash tool has been pushed to the repository but the workflow wasn't updated.

## Why

Fix workflow

## Issue

Solves #49

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
