### PR TITLE
chore: remove selectorLabels from job

### DIFF
--- a/charts/policy-hub/templates/job-policy-hub-migrations.yaml
+++ b/charts/policy-hub/templates/job-policy-hub-migrations.yaml
@@ -31,8 +31,7 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-        {{- include "phub.selectorLabels" . | nindent 8 }}
+      name: {{ .Values.policyhubmigrations.name }}-migrations
     spec:
       restartPolicy: Never
       containers:


### PR DESCRIPTION
## Description

remove selectorLabels from job

## Why

selectorLabels are unnecessary for job

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes