### PR TITLE
ci(release): fix push of tag triggering release workflow

### DIFF
--- a/.github/workflows/chart-release.yaml
+++ b/.github/workflows/chart-release.yaml
@@ -79,8 +79,8 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Push git tag for release workflow to be triggered
-        uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # v1.7.2
-        with:
-          tag: v${{ steps.chart-version.outputs.current }}
+      - name: Create and push git tag for release workflow to be triggered
+        run: |
+          git tag v${{ steps.chart-version.outputs.current }}
+          git push origin v${{ steps.chart-version.outputs.current }}
         if: steps.version-check.outputs.exists == 'false'


### PR DESCRIPTION
## Description

change from GH action to git push

## Why

creation of tag with GH action didn't trigger release workflow for docker image build

## Issue

https://github.com/eclipse-tractusx/portal/issues/188

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes