### PR TITLE
docs(policy): swagger document update

### DIFF
--- a/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
+++ b/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
@@ -46,7 +46,7 @@ public static class PolicyHubController
             .Produces(StatusCodes.Status200OK, typeof(string), Constants.JsonContentType);
 
         policyHub.MapGet("policy-types", (PolicyTypeId? type, UseCaseId? useCase, IPolicyHubBusinessLogic logic) => logic.GetPolicyTypes(type, useCase))
-            .WithSwaggerDescription("Gets the policy types",
+            .WithSwaggerDescription("Provides all current supported policy types incl. a policy description and useCase link.",
                 "Example: GET: api/policy-hub/policy-types",
                 "OPTIONAL: Type to filter the response",
                 "OPTIONAL: UseCase to filter the response")
@@ -57,24 +57,24 @@ public static class PolicyHubController
         policyHub.MapGet("policy-content",
                 (UseCaseId? useCase,
                 PolicyTypeId type,
-                string credential,
-                OperatorId operatorId,
+                string policyName,
+                OperatorId operatorType,
                 string? value,
-                IPolicyHubBusinessLogic logic) => logic.GetPolicyContentWithFiltersAsync(useCase, type, credential, operatorId, value))
-            .WithSwaggerDescription("Gets the content for a specific policy type",
+                IPolicyHubBusinessLogic logic) => logic.GetPolicyContentWithFiltersAsync(useCase, type, policyName, operatorType, value))
+            .WithSwaggerDescription("Receive the policy template 'access' or 'usage' for a single policy rule based on the request parameters submitted by the user.",
                 "Example: GET: api/policy-hub/policy-content",
                 "OPTIONAL: The use case",
-                "Type of the policy to get the content for",
+                "Policy type for which the policy is supposed to get created. Possible values: 'Access' or 'Usage'",
                 "The technical key of the policy",
-                "The operator of the left and right operand",
-                "OPTIONAL: Value for dynamic or regex operands")
+                "Policy Rule operator. Possible values: 'Equals' or 'In'",
+                "OPTIONAL: Value to be used for the rightOperand")
             .RequireAuthorization()
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(PolicyResponse), Constants.JsonContentType)
             .Produces(StatusCodes.Status404NotFound, typeof(ErrorResponse), Constants.JsonContentType);
 
         policyHub.MapPost("policy-content", ([FromBody] PolicyContentRequest requestData, IPolicyHubBusinessLogic logic) => logic.GetPolicyContentAsync(requestData))
-            .WithSwaggerDescription("Gets the content for a specific policy type",
+            .WithSwaggerDescription("Receive the policy template 'access' or 'usage' for multiple policy rule template based on the input request body.",
                 "Example: POST: api/policy-hub/policy-content",
                 "Request data with the configuration of the constraints")
             .RequireAuthorization()

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -136,7 +136,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_WithRegexWithIncorrectValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&credential=BusinessPartnerNumber&operatorId={OperatorId.Equals}&value=notmatching").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=notmatching").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();
@@ -150,7 +150,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_WithRegexWithoutValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&credential=BusinessPartnerNumber&operatorId={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();
@@ -164,7 +164,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_BpnWithValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&credential=BusinessPartnerNumber&operatorId={OperatorId.Equals}&value=BPNL00000003CRHK").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=BPNL00000003CRHK").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();
@@ -178,7 +178,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_UsageFrameworkEquals_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&credential=FrameworkAgreement.traceability&operatorId={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=FrameworkAgreement.traceability&operatorType={OperatorId.Equals}").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();
@@ -192,7 +192,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_UsageDismantlerIn_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&credential=companyRole.dismantler&operatorId={OperatorId.In}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=companyRole.dismantler&operatorType={OperatorId.In}").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();
@@ -206,7 +206,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_TraceabilityUsagePurposeEquals_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?useCase={UseCaseId.Traceability}&type={PolicyTypeId.Usage}&credential=purpose.trace.v1.TraceBattery&operatorId={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?useCase={UseCaseId.Traceability}&type={PolicyTypeId.Usage}&policyName=purpose.trace.v1.TraceBattery&operatorType={OperatorId.Equals}").ConfigureAwait(false);
 
         // Assert
         response.Should().NotBeNull();


### PR DESCRIPTION
## Description

Correct/Update the swagger docu of the policy hub.
Endpoint: /api/policy-hub/policy-types
Endpoint: /api/policy-hub/policy-content
Endpoint: /api/policy-hub/policy-content

## Why

Endpoint: /api/policy-hub/policy-types
Type: GET
 update the summary of the endpoint to "Provides all current supported policy types incl. a policy description and useCase link"

Endpoint: /api/policy-hub/policy-content
Type: GET

update the summary of the endpoint to "Receive the policy template "access" or "usage" for a single policy rule based on the request parameters submitted by the user."
recheck if the parameter "UseCase" is really needed. Please analyse once for what the parameter is used; share the information with the Product Owner and agree on the next steps
Update the description of the endpoint parameter Type to "Policy type for which the policy is supposed to get created. Possible values: "Access" or "Usage""
Change the parameter name credential to PolicyName
Change the parameter name operatorId to operatorType
Update the description of the endpoint parameter operatorId to "Policy Rule operator. Possible values: "Equals" or "In""
Update the description of the endpoint parameter value to "OPTIONAL: Value to be used for the rightOperand"

Endpoint: /api/policy-hub/policy-content
Type: POST

update the summary of the endpoint to "Receive the policy template "access" or "usage" for multiple policy rule template based on the input request body."

## Issue

#65 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)