### PR TITLE
fix(helm): fix label and username for external database

### DIFF
--- a/charts/policy-hub/templates/secret-external-db.yaml
+++ b/charts/policy-hub/templates/secret-external-db.yaml
@@ -24,7 +24,7 @@ metadata:
   name: {{ .Values.externalDatabase.existingSecret }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "portal.labels" . | nindent 4 }}
+    {{- include "phub.labels" . | nindent 4 }}
 type: Opaque
 # use lookup function to check if secret exists
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.externalDatabase.existingSecret) }}

--- a/charts/policy-hub/values.yaml
+++ b/charts/policy-hub/values.yaml
@@ -119,7 +119,7 @@ externalDatabase:
   # -- Database port number.
   port: 5432
   # -- Non-root username for policy-hub.
-  user: "hub"
+  username: "hub"
   # -- Database name.
   database: "policy-hub"
   # -- Password for the non-root username (default 'hub'). Secret-key 'password'.


### PR DESCRIPTION
## Description

- fix label and username for external database

## Why

disabling the db dependency results in an error

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes