### PR TITLE
feat(policy): policy seeding data update

### DIFF
--- a/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
+++ b/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
@@ -87,5 +87,37 @@
     "description": "",
     "is_active": true,
     "attribute_key_id": 3
+  },
+  {
+    "id": "01a0fba3-9b6e-435a-b045-e0e890c300c3",
+    "kind_id": 3,
+    "technical_key": "FrameworkAgreement.circulareconomy",
+    "description": "With the Framework Credential, only those participants which have signed the respective framework agreement (general or via a specific version) are allowed to view or negotiate the respective data offer. Generic: \"rightOperand\": \"active\"; specific \"rightOperand\": \"active:{version}\"",
+    "is_active": true,
+    "attribute_key_id": 5
+  },
+  {
+    "id": "01a0fba3-9b6e-435a-b045-e0e890c300c4",
+    "kind_id": 3,
+    "technical_key": "FrameworkAgreement.demandcapacity",
+    "description": "With the Framework Credential, only those participants which have signed the respective framework agreement (general or via a specific version) are allowed to view or negotiate the respective data offer. Generic: \"rightOperand\": \"active\"; specific \"rightOperand\": \"active:{version}\"",
+    "is_active": true,
+    "attribute_key_id": 5
+  },
+  {
+    "id": "01a0fba3-9b6e-435a-b045-e0e890c300c5",
+    "kind_id": 3,
+    "technical_key": "FrameworkAgreement.puris",
+    "description": "With the Framework Credential, only those participants which have signed the respective framework agreement (general or via a specific version) are allowed to view or negotiate the respective data offer. Generic: \"rightOperand\": \"active\"; specific \"rightOperand\": \"active:{version}\"",
+    "is_active": true,
+    "attribute_key_id": 5
+  },
+  {
+    "id": "01a0fba3-9b6e-435a-b045-e0e890c300c6",
+    "kind_id": 3,
+    "technical_key": "FrameworkAgreement.businesspartner",
+    "description": "With the Framework Credential, only those participants which have signed the respective framework agreement (general or via a specific version) are allowed to view or negotiate the respective data offer. Generic: \"rightOperand\": \"active\"; specific \"rightOperand\": \"active:{version}\"",
+    "is_active": true,
+    "attribute_key_id": 5
   }
 ]

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -61,7 +61,7 @@ public class PolicyHubBusinessLogic : IPolicyHubBusinessLogic
             GetRightOperand(operatorId, attributes, rightOperands, value, leftOperand) :
             (rightOperandValue!, null);
 
-        return new PolicyResponse(CreateFileContent(type, operatorId, leftOperand, rightOperand), additionalAttribute == null ? null : Enumerable.Repeat(additionalAttribute, 1));
+        return new PolicyResponse(CreateFileContent(type, operatorId, "cx-policy:" + leftOperand, rightOperand), additionalAttribute == null ? null : Enumerable.Repeat(additionalAttribute, 1));
     }
 
     private static (object rightOperand, AdditionalAttributes? additionalAttribute) GetRightOperand(OperatorId operatorId, (AttributeKeyId? Key, IEnumerable<string> Values) attributes, IEnumerable<string> rightOperands, string? value, string leftOperand) =>
@@ -149,7 +149,7 @@ public class PolicyHubBusinessLogic : IPolicyHubBusinessLogic
 
             constraints.Add(new Constraint(null,
                 null,
-                policy.LeftOperand,
+                "cx-policy:" + policy.LeftOperand,
                 constraint.Operator.OperatorToJsonString(),
                 rightOperand
             ));

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
@@ -70,7 +70,7 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetPolicyTypes(null, null).ToListAsync().ConfigureAwait(false);
 
         // Assert
-        result.Should().NotBeEmpty().And.HaveCount(11).And.Satisfy(
+        result.Should().NotBeEmpty().And.HaveCount(15).And.Satisfy(
             x => x.TechnicalKey == "BusinessPartnerNumber",
             x => x.TechnicalKey == "Membership",
             x => x.TechnicalKey == "FrameworkAgreement.traceability",
@@ -81,7 +81,12 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
             x => x.TechnicalKey == "purpose.trace.v1.aspects",
             x => x.TechnicalKey == "companyRole.dismantler",
             x => x.TechnicalKey == "purpose.trace.v1.qualityanalysis",
-            x => x.TechnicalKey == "purpose"
+            x => x.TechnicalKey == "purpose",
+            x => x.TechnicalKey == "FrameworkAgreement.circulareconomy",
+            x => x.TechnicalKey == "FrameworkAgreement.demandcapacity",
+            x => x.TechnicalKey == "FrameworkAgreement.puris",
+            x => x.TechnicalKey == "FrameworkAgreement.businesspartner"
+
         );
     }
 

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -182,7 +182,7 @@ public class PolicyHubBusinessLogicTests
                 x => x == "value3"
             );
         result.Content.Permission.Constraint.RightOperandValue.Should().Be("@multipleAdditionalValues-Static");
-        result.Content.Permission.Constraint.LeftOperand.Should().Be("multipleAdditionalValues");
+        result.Content.Permission.Constraint.LeftOperand.Should().Be("cx-policy:multipleAdditionalValues");
         result.Content.Permission.Constraint.Operator.Should().Be("eq");
         result.Content.Permission.Constraint.AndOperands.Should().BeNull();
         result.Content.Permission.Constraint.OrOperands.Should().BeNull();
@@ -332,10 +332,10 @@ public class PolicyHubBusinessLogicTests
         result.Content.Permission.Constraint.AndOperands.Should().BeNull();
         result.Content.Permission.Constraint.OrOperands.Should().HaveCount(4)
             .And.Satisfy(
-                x => x.LeftOperand == "active" && x.Operator == "in" && ((x.RightOperandValue as IEnumerable<string>)!).Count() == 2,
-                x => x.LeftOperand == "active" && x.Operator == "eq" && x.RightOperandValue as string == "BPNL00000001TEST",
-                x => x.LeftOperand == "active" && x.Operator == "eq" && x.RightOperandValue as string == "{dynamicValue}",
-                x => x.LeftOperand == "active" && x.Operator == "eq" && x.RightOperandValue as string == "test");
+                x => x.LeftOperand == "cx-policy:active" && x.Operator == "in" && ((x.RightOperandValue as IEnumerable<string>)!).Count() == 2,
+                x => x.LeftOperand == "cx-policy:active" && x.Operator == "eq" && x.RightOperandValue as string == "BPNL00000001TEST",
+                x => x.LeftOperand == "cx-policy:active" && x.Operator == "eq" && x.RightOperandValue as string == "{dynamicValue}",
+                x => x.LeftOperand == "cx-policy:active" && x.Operator == "eq" && x.RightOperandValue as string == "test");
     }
 
     [Fact]
@@ -366,8 +366,8 @@ public class PolicyHubBusinessLogicTests
         result.Content.Permission.Constraint.OrOperands.Should().BeNull();
         result.Content.Permission.Constraint.AndOperands.Should().HaveCount(2)
             .And.Satisfy(
-                x => x.LeftOperand == "multipleAdditionalValues" && x.Operator == "eq" && x.RightOperandValue as string == "@multipleAdditionalValues-Static",
-                x => x.LeftOperand == "test" && x.Operator == "in" && (x.RightOperandValue as IEnumerable<string>)!.Count() == 2);
+                x => x.LeftOperand == "cx-policy:multipleAdditionalValues" && x.Operator == "eq" && x.RightOperandValue as string == "@multipleAdditionalValues-Static",
+                x => x.LeftOperand == "cx-policy:test" && x.Operator == "in" && (x.RightOperandValue as IEnumerable<string>)!.Count() == 2);
         result.AdditionalAttributes.Should().ContainSingle()
             .And.Satisfy(x => x.Key == "@multipleAdditionalValues-Static");
         result.AdditionalAttributes!.Single().PossibleValues.Should().HaveCount(3)

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -78,7 +78,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
 
         // Assert
         policies.Should().NotBeNull()
-            .And.HaveCount(11).And.Satisfy(
+            .And.HaveCount(15).And.Satisfy(
                 x => x.TechnicalKey == "BusinessPartnerNumber",
                 x => x.TechnicalKey == "Membership",
                 x => x.TechnicalKey == "FrameworkAgreement.traceability",
@@ -89,7 +89,11 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
                 x => x.TechnicalKey == "purpose.trace.v1.aspects",
                 x => x.TechnicalKey == "companyRole.dismantler",
                 x => x.TechnicalKey == "purpose.trace.v1.qualityanalysis",
-                x => x.TechnicalKey == "purpose"
+                x => x.TechnicalKey == "purpose",
+                x => x.TechnicalKey == "FrameworkAgreement.circulareconomy",
+                x => x.TechnicalKey == "FrameworkAgreement.demandcapacity",
+                x => x.TechnicalKey == "FrameworkAgreement.puris",
+                x => x.TechnicalKey == "FrameworkAgreement.businesspartner"
             );
     }
 
@@ -171,7 +175,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
     }
 
     [Fact]
@@ -185,7 +189,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
 
     [Fact]
@@ -199,7 +203,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}}}}");
     }
 
     [Fact]
@@ -213,7 +217,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"purpose.trace.v1.TraceBattery\",\"operator\":\"eq\",\"rightOperand\":\"purpose.trace.v1.TraceBattery\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:purpose.trace.v1.TraceBattery\",\"operator\":\"eq\",\"rightOperand\":\"purpose.trace.v1.TraceBattery\"}}}}");
     }
 
     #endregion
@@ -241,7 +245,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"cx-policy:Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
 
     [Fact]
@@ -266,7 +270,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"cx-policy:Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
 
     [Fact]
@@ -290,7 +294,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:or\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:or\":[{\"leftOperand\":\"cx-policy:FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"cx-policy:Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Update policy hub seeding data to the latest and greatest policy definition.
GET /api/policy-hub/policy-content
POST /api/policy-hub/policy-content

## Why

The policy namespaces (leftOperand and rightOperand values) got recently updated and need to get adjusted for the policy hub.

## Issue

#25 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)