### PR TITLE
feat(net8): upgrade to .net8

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['7.0']
+        dotnet-version: ['8.0']
 
     steps:
       - name: Set up JDK 17

--- a/.github/workflows/test-automation.yml
+++ b/.github/workflows/test-automation.yml
@@ -29,7 +29,7 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     strategy:
       matrix:
-        dotnet-version: [ '7.0' ]
+        dotnet-version: [ '8.0' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit.tests-formatting.yml
+++ b/.github/workflows/unit.tests-formatting.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['7.0']
+        dotnet-version: ['8.0']
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,49 +1,53 @@
 nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.18.0, MIT, approved, #10064
+nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.18.1, MIT, approved, #10064
 nuget/nuget/-/AutoFixture.Xunit/4.18.0, MIT, approved, #10082
+nuget/nuget/-/AutoFixture.Xunit/4.18.1, MIT, approved, #10082
 nuget/nuget/-/AutoFixture/4.18.0, MIT, approved, #10057
-nuget/nuget/-/Castle.Core/4.3.1, Apache-2.0, approved, clearlydefined
-nuget/nuget/-/EFCore.NamingConventions/7.0.2, Apache-2.0, approved, #10067
-nuget/nuget/-/FakeItEasy/7.4.0, MIT, approved, #10080
+nuget/nuget/-/AutoFixture/4.18.1, MIT, approved, #10057
+nuget/nuget/-/BouncyCastle.Cryptography/2.2.1, MIT AND Apache-2.0 AND BSD-3-Clause AND LicenseRef-Permission-Notice, approved, #10066
+nuget/nuget/-/Castle.Core/5.1.1, Apache-2.0, approved, #13966
+nuget/nuget/-/EFCore.NamingConventions/8.0.3, Apache-2.0, approved, #13983
+nuget/nuget/-/FakeItEasy/8.1.0, MIT, approved, #13970
 nuget/nuget/-/Fare/2.1.1, MIT, approved, clearlydefined
 nuget/nuget/-/FluentAssertions/6.11.0, Apache-2.0 AND MIT, approved, #10061
+nuget/nuget/-/FluentAssertions/6.12.0, MIT AND Apache-2.0 AND BSD-3-Clause AND CC-BY-3.0-US AND (GPL-2.0-only OR MIT) AND OFL-1.1 AND WTFPL, approved, #13976
 nuget/nuget/-/Flurl.Signed/3.0.6, MIT, approved, #3501
 nuget/nuget/-/Humanizer.Core/2.14.1, MIT, approved, #10060
 nuget/nuget/-/Mono.TextTemplating/2.2.1, MIT, approved, clearlydefined
 nuget/nuget/-/Newtonsoft.Json/13.0.1, MIT AND BSD-3-Clause, approved, #3266
 nuget/nuget/-/Newtonsoft.Json/13.0.3, MIT AND BSD-3-Clause, approved, #3266
-nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/7.0.11, PostgreSQL AND MIT AND Apache-2.0, approved, #10081
-nuget/nuget/-/Npgsql/7.0.6, PostgreSQL, approved, #10062
-nuget/nuget/-/Portable.BouncyCastle/1.9.0, MIT, approved, clearlydefined
-nuget/nuget/-/SSH.NET/2020.0.2, MIT AND ISC AND LicenseRef-Public-domain AND (MIT AND MS-PL), approved, #10073
-nuget/nuget/-/Serilog.AspNetCore/7.0.0, Apache-2.0 AND MIT, approved, #10084
+nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/8.0.2, PostgreSQL AND MIT, approved, #13972
+nuget/nuget/-/Npgsql/8.0.2, PostgreSQL, approved, #13963
+nuget/nuget/-/SSH.NET/2023.0.0, MIT AND (MIT AND MS-PL) AND ISC, approved, #13965
+nuget/nuget/-/Serilog.AspNetCore/8.0.1, Apache-2.0 AND MIT, approved, #13967
 nuget/nuget/-/Serilog.Enrichers.CorrelationId/3.0.1, MIT, approved, clearlydefined
-nuget/nuget/-/Serilog.Enrichers.Environment/2.2.0, Apache-2.0, approved, clearlydefined
+nuget/nuget/-/Serilog.Enrichers.Environment/2.3.0, Apache-2.0, approved, #13959
 nuget/nuget/-/Serilog.Enrichers.Process/2.0.2, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Sensitive/1.7.3, MIT, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0, Apache-2.0, approved, clearlydefined
-nuget/nuget/-/Serilog.Extensions.Hosting/7.0.0, Apache-2.0, approved, #10078
-nuget/nuget/-/Serilog.Extensions.Logging/7.0.0, Apache-2.0, approved, #10070
-nuget/nuget/-/Serilog.Formatting.Compact/1.1.0, Apache-2.0, approved, #11115
-nuget/nuget/-/Serilog.Settings.Configuration/7.0.0, Apache-2.0, approved, #10069
-nuget/nuget/-/Serilog.Sinks.Console/4.1.0, Apache-2.0, approved, #8434
+nuget/nuget/-/Serilog.Extensions.Hosting/8.0.0, Apache-2.0, approved, #13962
+nuget/nuget/-/Serilog.Extensions.Logging/8.0.0, Apache-2.0, approved, #13985
+nuget/nuget/-/Serilog.Formatting.Compact/2.0.0, Apache-2.0, approved, #13981
+nuget/nuget/-/Serilog.Settings.Configuration/8.0.0, Apache-2.0, approved, #13988
+nuget/nuget/-/Serilog.Sinks.Console/5.0.1, Apache-2.0, approved, #13980
 nuget/nuget/-/Serilog.Sinks.Debug/2.0.0, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Sinks.File/5.0.0, Apache-2.0, approved, #11116
-nuget/nuget/-/Serilog/3.0.1, Apache-2.0, approved, #10063
+nuget/nuget/-/Serilog/3.1.1, Apache-2.0, approved, #13978
 nuget/nuget/-/SharpZipLib/1.4.2, MIT AND GFDL-1.3-or-later AND (Apache-2.0 AND MIT) AND WTFPL AND bzip2-1.0.6 AND LicenseRef-Permissive-license-with-conditions AND LicenseRef-Permission-Notice, approved, #10058
 nuget/nuget/-/SshNet.Security.Cryptography/1.3.0, MIT, approved, clearlydefined
 nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/6.5.0, MIT AND Apache-2.0, approved, #7160
 nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/6.5.0, MIT AND Apache-2.0, approved, #7156
 nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/6.5.0, MIT AND Apache-2.0, approved, #7158
 nuget/nuget/-/Swashbuckle.AspNetCore/6.5.0, MIT AND Apache-2.0, approved, #7159
-nuget/nuget/-/Testcontainers.PostgreSql/3.4.0, MIT, approved, #10056
-nuget/nuget/-/Testcontainers/3.4.0, MIT, approved, #10083
+nuget/nuget/-/Testcontainers.PostgreSql/3.7.0, MIT, approved, #13960
+nuget/nuget/-/Testcontainers/3.7.0, MIT, approved, #13982
 nuget/nuget/-/Xunit.Extensions.AssemblyFixture/2.4.1, MIT, approved, #3502
-nuget/nuget/-/coverlet.collector/6.0.0, MIT, approved, #10075
+nuget/nuget/-/coverlet.collector/6.0.2, MIT, approved, #10075
 nuget/nuget/-/xunit.abstractions/2.0.3, Apache-2.0, approved, clearlydefined
-nuget/nuget/-/xunit.analyzers/1.2.0, Apache-2.0 AND MIT, approved, #10068
-nuget/nuget/-/xunit.assert/2.5.0, Apache-2.0 AND MIT, approved, #10071
-nuget/nuget/-/xunit.core/2.5.0, Apache-2.0 AND MIT, approved, #10059
-nuget/nuget/-/xunit.extensibility.core/2.5.0, Apache-2.0 AND MIT, approved, #10077
-nuget/nuget/-/xunit.extensibility.execution/2.5.0, Apache-2.0 AND MIT, approved, #10074
-nuget/nuget/-/xunit.runner.visualstudio/2.5.0, Apache-2.0 AND MIT, approved, #10065
-nuget/nuget/-/xunit/2.5.0, Apache-2.0 AND MIT, approved, #10072
+nuget/nuget/-/xunit.analyzers/1.11.0, Apache-2.0 AND MIT, approved, #14197
+nuget/nuget/-/xunit.assert/2.7.0, Apache-2.0 AND MIT, approved, #13971
+nuget/nuget/-/xunit.core/2.7.0, Apache-2.0, approved, #13979
+nuget/nuget/-/xunit.extensibility.core/2.7.0, Apache-2.0 AND MIT, approved, #13974
+nuget/nuget/-/xunit.extensibility.execution/2.7.0, Apache-2.0, approved, #13977
+nuget/nuget/-/xunit.runner.visualstudio/2.5.7, Apache-2.0 AND MIT, approved, #10065
+nuget/nuget/-/xunit/2.7.0, Apache-2.0 AND MIT, approved, #13969

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For **installation** details, please refer to the [README.md](./charts/policy-hu
 
 ## How to build and run
 
-Install the [.NET 7.0 SDK](https://www.microsoft.com/net/download).
+Install the [.NET 8.0 SDK](https://www.microsoft.com/net/download).
 
 Run the following command from the CLI:
 

--- a/docker/Dockerfile-policy-hub-migrations
+++ b/docker/Dockerfile-policy-hub-migrations
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY /src/database /src/database

--- a/docker/Dockerfile-policy-hub-service
+++ b/docker/Dockerfile-policy-hub-service
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
 COPY src/ src/

--- a/docker/notice-policy-hub-migrations.md
+++ b/docker/notice-policy-hub-migrations.md
@@ -13,7 +13,7 @@ __Policy Hub Migrations__
 
 __Used base images__
 
-- Dockerfile: [mcr.microsoft.com/dotnet/runtime:7.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime/7.0/alpine3.19/amd64/Dockerfile)
+- Dockerfile: [mcr.microsoft.com/dotnet/runtime:8.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime/8.0/alpine3.19/amd64/Dockerfile)
 - GitHub project: [https://github.com/dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker)
 - DockerHub: [https://hub.docker.com/_/microsoft-dotnet-runtime](https://hub.docker.com/_/microsoft-dotnet-runtime)
 

--- a/docker/notice-policy-hub-service.md
+++ b/docker/notice-policy-hub-service.md
@@ -13,7 +13,7 @@ __Policy Hub Service__
 
 __Used base images__
 
-- Dockerfile: [mcr.microsoft.com/dotnet/aspnet:7.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/7.0/alpine3.19/amd64/Dockerfile)
+- Dockerfile: [mcr.microsoft.com/dotnet/aspnet:8.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/8.0/alpine3.19/amd64/Dockerfile)
 - GitHub project: [https://github.com/dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker)
 - DockerHub: [https://hub.docker.com/_/microsoft-dotnet-aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet)
 

--- a/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
+++ b/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.DbAccess</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.DbAccess</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.12" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="1.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
+++ b/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
@@ -21,17 +21,17 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Entities</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Entities</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.10">
+    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
   </ItemGroup>
   <ItemGroup>
     <SonarQubeSetting Include="sonar.coverage.exclusions">

--- a/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
+++ b/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Migrations</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Migrations</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -33,21 +33,21 @@
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="1.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="1.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
+++ b/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
@@ -23,7 +23,7 @@ using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.BusinessLogic;
 using Org.Eclipse.TractusX.PolicyHub.Service.Extensions;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Controllers;

--- a/src/hub/PolicyHub.Service/Extensions/RouteHandlerBuilderExtensions.cs
+++ b/src/hub/PolicyHub.Service/Extensions/RouteHandlerBuilderExtensions.cs
@@ -17,7 +17,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Extensions;

--- a/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
+++ b/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Service</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Service</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -34,9 +34,9 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Signed" Version="3.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.10" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.0.0" />
     <PackageReference Include="System.Json" Version="4.7.1" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/database/PolicyHub.DbAccess.Tests/HubRepositoriesTests.cs
+++ b/tests/database/PolicyHub.DbAccess.Tests/HubRepositoriesTests.cs
@@ -8,7 +8,9 @@ public class HubRepositoriesTests : IAssemblyFixture<TestDbFixture>
 {
     private readonly TestDbFixture _dbTestDbFixture;
 
+#pragma warning disable xUnit1041 // Fixture arguments to test classes must have fixture sources
     public HubRepositoriesTests(TestDbFixture testDbFixture)
+#pragma warning restore xUnit1041 // Fixture arguments to test classes must have fixture sources
     {
         _dbTestDbFixture = testDbFixture;
     }
@@ -18,7 +20,7 @@ public class HubRepositoriesTests : IAssemblyFixture<TestDbFixture>
     [Fact]
     public async Task GetInstance_WithValid_ReturnsExpected()
     {
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         var repo = sut.GetInstance<IPolicyRepository>();
 

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.DbAccess.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.DbAccess.Tests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -32,23 +32,23 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Testcontainers" Version="3.4.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="Testcontainers" Version="3.7.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
@@ -31,7 +31,9 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
 {
     private readonly TestDbFixture _dbTestDbFixture;
 
+#pragma warning disable xUnit1041 // Fixture arguments to test classes must have fixture sources
     public PolicyRepositoryTests(TestDbFixture testDbFixture)
+#pragma warning restore xUnit1041 // Fixture arguments to test classes must have fixture sources
     {
         _dbTestDbFixture = testDbFixture;
     }
@@ -42,10 +44,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetAttributeKeys_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetAttributeKeys().ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetAttributeKeys().ToListAsync();
 
         // Assert
         result.Should().NotBeEmpty().And.HaveCount(5).And.Satisfy(
@@ -64,10 +66,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyTypes_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyTypes(null, null).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetPolicyTypes(null, null).ToListAsync();
 
         // Assert
         result.Should().NotBeEmpty().And.HaveCount(11).And.Satisfy(
@@ -89,10 +91,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyTypes_WithTypeFilter_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyTypes(PolicyTypeId.Access, null).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetPolicyTypes(PolicyTypeId.Access, null).ToListAsync();
 
         // Assert
         result.Should().NotBeEmpty().And.HaveCount(3).And.Satisfy(
@@ -106,10 +108,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyTypes_WithUseCase_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyTypes(null, UseCaseId.Sustainability).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetPolicyTypes(null, UseCaseId.Sustainability).ToListAsync();
 
         // Assert
         result.Should().NotBeEmpty().And.HaveCount(3).And.Satisfy(
@@ -127,10 +129,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyContentAsync_WithoutRightOperand_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyContentAsync(null, PolicyTypeId.Usage, "purpose.trace.v1.TraceBattery").ConfigureAwait(false);
+        var result = await sut.GetPolicyContentAsync(null, PolicyTypeId.Usage, "purpose.trace.v1.TraceBattery");
 
         // Assert
         result.Exists.Should().BeTrue();
@@ -145,10 +147,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyContentAsync_WithRightOperand_ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyContentAsync(null, PolicyTypeId.Usage, "FrameworkAgreement.behavioraltwin").ConfigureAwait(false);
+        var result = await sut.GetPolicyContentAsync(null, PolicyTypeId.Usage, "FrameworkAgreement.behavioraltwin");
 
         // Assert
         result.Exists.Should().BeTrue();
@@ -167,10 +169,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
     public async Task GetPolicyForOperandContent__ReturnsExpectedResult()
     {
         // Arrange
-        var sut = await CreateSut().ConfigureAwait(false);
+        var sut = await CreateSut();
 
         // Act
-        var result = await sut.GetPolicyForOperandContent(PolicyTypeId.Usage, Enumerable.Repeat("purpose.trace.v1.TraceBattery", 1)).ToListAsync().ConfigureAwait(false);
+        var result = await sut.GetPolicyForOperandContent(PolicyTypeId.Usage, Enumerable.Repeat("purpose.trace.v1.TraceBattery", 1)).ToListAsync();
 
         // Assert
         result.Should().ContainSingle()

--- a/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
+++ b/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Entities.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Entities.Tests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -34,17 +34,17 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/hub/PolicyHub.Service.Tests/Authentication/KeycloakClaimsTransformationTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Authentication/KeycloakClaimsTransformationTests.cs
@@ -50,7 +50,7 @@ public class KeycloakClaimsTransformationTests
         var principal = new ClaimsPrincipal(identity);
 
         // Act
-        var result = await _sut.TransformAsync(principal).ConfigureAwait(false);
+        var result = await _sut.TransformAsync(principal);
 
         // Assert
         result.Claims.Should().ContainSingle()
@@ -66,7 +66,7 @@ public class KeycloakClaimsTransformationTests
         var principal = new ClaimsPrincipal(identity);
 
         // Act
-        var result = await _sut.TransformAsync(principal).ConfigureAwait(false);
+        var result = await _sut.TransformAsync(principal);
 
         // Assert
         result.Claims.Should().HaveCount(2).And.Satisfy(
@@ -83,7 +83,7 @@ public class KeycloakClaimsTransformationTests
         var principal = new ClaimsPrincipal(identity);
 
         // Act
-        var result = await _sut.TransformAsync(principal).ConfigureAwait(false);
+        var result = await _sut.TransformAsync(principal);
 
         // Assert
         result.Claims.Should().ContainSingle()

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -58,7 +58,7 @@ public class PolicyHubBusinessLogicTests
         Setup_GetAttributeKeys();
 
         // Act
-        var result = await _sut.GetAttributeKeys().ToListAsync().ConfigureAwait(false);
+        var result = await _sut.GetAttributeKeys().ToListAsync();
 
         // Assert
         result.Should().HaveCount(5);
@@ -75,7 +75,7 @@ public class PolicyHubBusinessLogicTests
         Setup_GetPolicyTypes();
 
         // Act
-        var result = await _sut.GetPolicyTypes(null, null).ToListAsync().ConfigureAwait(false);
+        var result = await _sut.GetPolicyTypes(null, null).ToListAsync();
 
         // Assert
         result.Should().HaveCount(2);
@@ -88,7 +88,7 @@ public class PolicyHubBusinessLogicTests
         Setup_GetPolicyTypes();
 
         // Act
-        var result = await _sut.GetPolicyTypes(null, UseCaseId.Sustainability).ToListAsync().ConfigureAwait(false);
+        var result = await _sut.GetPolicyTypes(null, UseCaseId.Sustainability).ToListAsync();
 
         // Assert
         result.Should().ContainSingle();
@@ -105,7 +105,7 @@ public class PolicyHubBusinessLogicTests
         const PolicyTypeId policyTypeId = PolicyTypeId.Access;
         A.CallTo(() => _policyRepository.GetPolicyContentAsync(null, policyTypeId, "membership"))
             .Returns(new ValueTuple<bool, string, (AttributeKeyId, IEnumerable<string>), string?>(false, null!, default, null!));
-        async Task Act() => await _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, null);
+        Task Act() => _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, null);
 
         // Act
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
@@ -121,7 +121,7 @@ public class PolicyHubBusinessLogicTests
         const PolicyTypeId policyTypeId = PolicyTypeId.Access;
         A.CallTo(() => _policyRepository.GetPolicyContentAsync(null, policyTypeId, "membership"))
             .Returns(new ValueTuple<bool, string, (AttributeKeyId?, IEnumerable<string>), string?>(true, "test", (null, Enumerable.Empty<string>()), null!));
-        async Task Act() => await _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, null);
+        Task Act() => _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, null);
 
         // Act
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
@@ -152,10 +152,10 @@ public class PolicyHubBusinessLogicTests
         const PolicyTypeId policyTypeId = PolicyTypeId.Access;
         A.CallTo(() => _policyRepository.GetPolicyContentAsync(null, policyTypeId, "membership"))
             .Returns(new ValueTuple<bool, string, (AttributeKeyId?, IEnumerable<string>), string?>(true, "test", (AttributeKeyId.Regex, new[] { "test1", "test2" }), null));
-        async Task Act() => await _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, "test");
+        Task Act() => _sut.GetPolicyContentWithFiltersAsync(null, policyTypeId, "membership", OperatorId.Equals, "test");
 
         // Act
-        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
 
         // Assert
         ex.Message.Should().Be("There should only be one regex pattern defined");
@@ -169,7 +169,7 @@ public class PolicyHubBusinessLogicTests
             .Returns(new ValueTuple<bool, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>(true, "multipleAdditionalValues", new ValueTuple<AttributeKeyId, IEnumerable<string>>(AttributeKeyId.Static, new[] { "value1", "value2", "value3" }), null));
 
         // Act
-        var result = await _sut.GetPolicyContentWithFiltersAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues", OperatorId.Equals, "test").ConfigureAwait(false);
+        var result = await _sut.GetPolicyContentWithFiltersAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues", OperatorId.Equals, "test");
 
         // Assert
         result.Content.Id.Should().Be("....");
@@ -204,10 +204,10 @@ public class PolicyHubBusinessLogicTests
             });
         A.CallTo(() => _policyRepository.GetPolicyForOperandContent(data.PolicyType, A<IEnumerable<string>>._))
             .Returns(Enumerable.Repeat(new ValueTuple<string, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>("test", "active", default, null), 1).ToAsyncEnumerable());
-        async Task Act() => await _sut.GetPolicyContentAsync(data);
+        Task Act() => _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<NotFoundException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
 
         // Assert
         ex.Message.Should().Be($"Policy for type {data.PolicyType} and technicalKeys abc does not exists");
@@ -224,10 +224,10 @@ public class PolicyHubBusinessLogicTests
             });
         A.CallTo(() => _policyRepository.GetPolicyForOperandContent(data.PolicyType, A<IEnumerable<string>>._))
             .Returns(Enumerable.Repeat(new ValueTuple<string, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>("test", "active", (null, Enumerable.Empty<string>()), null), 1).ToAsyncEnumerable());
-        async Task Act() => await _sut.GetPolicyContentAsync(data);
+        Task Act() => _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
 
         // Assert
         ex.Message.Should().Be("There must be one configured rightOperand value");
@@ -244,10 +244,10 @@ public class PolicyHubBusinessLogicTests
             });
         A.CallTo(() => _policyRepository.GetPolicyForOperandContent(data.PolicyType, A<IEnumerable<string>>._))
             .Returns(Enumerable.Repeat(new ValueTuple<string, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>("test", "active", (AttributeKeyId.Regex, Enumerable.Repeat(@"^BPNL[\w|\d]{12}$", 1)), null), 1).ToAsyncEnumerable());
-        async Task Act() => await _sut.GetPolicyContentAsync(data);
+        Task Act() => _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
         ex.ParamName.Should().Be("value");
@@ -265,10 +265,10 @@ public class PolicyHubBusinessLogicTests
             });
         A.CallTo(() => _policyRepository.GetPolicyForOperandContent(data.PolicyType, A<IEnumerable<string>>._))
             .Returns(Enumerable.Repeat(new ValueTuple<string, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>("test", "active", (AttributeKeyId.Regex, Enumerable.Repeat(@"^BPNL[\w|\d]{12}$", 1)), null), 1).ToAsyncEnumerable());
-        async Task Act() => await _sut.GetPolicyContentAsync(data);
+        Task Act() => _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
         ex.ParamName.Should().Be("value");
@@ -290,10 +290,10 @@ public class PolicyHubBusinessLogicTests
             {
                 new ValueTuple<string, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>("test", "active", default, null)
             }.ToAsyncEnumerable());
-        async Task Act() => await _sut.GetPolicyContentAsync(data);
+        Task Act() => _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
         ex.Message.Should().Be("Keys test have been defined multiple times");
@@ -321,7 +321,7 @@ public class PolicyHubBusinessLogicTests
             }.ToAsyncEnumerable());
 
         // Act
-        var result = await _sut.GetPolicyContentAsync(data).ConfigureAwait(false);
+        var result = await _sut.GetPolicyContentAsync(data);
 
         // Assert
         result.Content.Id.Should().Be("....");
@@ -355,7 +355,7 @@ public class PolicyHubBusinessLogicTests
             }.ToAsyncEnumerable());
 
         // Act
-        var result = await _sut.GetPolicyContentAsync(data).ConfigureAwait(false);
+        var result = await _sut.GetPolicyContentAsync(data);
 
         // Assert
         result.Content.Id.Should().Be("....");

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -21,7 +21,7 @@ using Org.Eclipse.TractusX.PolicyHub.DbAccess.Models;
 using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
 using Org.Eclipse.TractusX.PolicyHub.Service.Tests.Setup;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
@@ -54,7 +54,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetAttributes()
     {
         // Act
-        var attributes = await _client.GetFromJsonAsync<IEnumerable<string>>($"{BaseUrl}/policy-attributes").ConfigureAwait(false);
+        var attributes = await _client.GetFromJsonAsync<IEnumerable<string>>($"{BaseUrl}/policy-attributes");
 
         // Assert
         attributes.Should().NotBeNull().And.HaveCount(5).And.Satisfy(
@@ -74,7 +74,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyTypes_WithoutFilter_ReturnsExpected()
     {
         // Act
-        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types", JsonOptions).ConfigureAwait(false);
+        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types", JsonOptions);
 
         // Assert
         policies.Should().NotBeNull()
@@ -97,7 +97,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyTypes_WithTypeFilter_ReturnsExpected()
     {
         // Act
-        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types?type={PolicyTypeId.Access.ToString()}", JsonOptions).ConfigureAwait(false);
+        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types?type={PolicyTypeId.Access}", JsonOptions);
 
         // Assert
         policies.Should().NotBeNull()
@@ -112,7 +112,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyTypes_WithUseCaseFilter_ReturnsExpected()
     {
         // Act
-        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types?useCase={UseCaseId.Traceability.ToString()}", JsonOptions).ConfigureAwait(false);
+        var policies = await _client.GetFromJsonAsync<IEnumerable<PolicyTypeResponse>>($"{BaseUrl}/policy-types?useCase={UseCaseId.Traceability}", JsonOptions);
 
         // Assert
         policies.Should().NotBeNull()
@@ -136,12 +136,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_WithRegexWithIncorrectValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=notmatching").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=notmatching");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions).ConfigureAwait(false);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
         error!.Errors.Should().ContainSingle().And.Satisfy(
             x => x.Value.Single() == @"The provided value notmatching does not match the regex pattern ^BPNL[\w|\d]{12}$ (Parameter 'value')");
     }
@@ -150,12 +150,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_WithRegexWithoutValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Access}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions).ConfigureAwait(false);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
         error!.Errors.Should().ContainSingle().And.Satisfy(
             x => x.Value.Single() == "you must provide a value for the regex (Parameter 'value')");
     }
@@ -164,12 +164,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_BpnWithValue_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=BPNL00000003CRHK").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=BusinessPartnerNumber&operatorType={OperatorId.Equals}&value=BPNL00000003CRHK");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
     }
@@ -178,12 +178,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_UsageFrameworkEquals_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=FrameworkAgreement.traceability&operatorType={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=FrameworkAgreement.traceability&operatorType={OperatorId.Equals}");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
@@ -192,12 +192,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_UsageDismantlerIn_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=companyRole.dismantler&operatorType={OperatorId.In}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=companyRole.dismantler&operatorType={OperatorId.In}");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}}}}");
     }
@@ -206,12 +206,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task GetPolicyContent_TraceabilityUsagePurposeEquals_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/policy-content?useCase={UseCaseId.Traceability}&type={PolicyTypeId.Usage}&policyName=purpose.trace.v1.TraceBattery&operatorType={OperatorId.Equals}").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/policy-content?useCase={UseCaseId.Traceability}&type={PolicyTypeId.Usage}&policyName=purpose.trace.v1.TraceBattery&operatorType={OperatorId.Equals}");
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"purpose.trace.v1.TraceBattery\",\"operator\":\"eq\",\"rightOperand\":\"purpose.trace.v1.TraceBattery\"}}}}");
     }
@@ -234,12 +234,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             });
 
         // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
@@ -259,12 +259,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             });
 
         // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
@@ -283,12 +283,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             });
 
         // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+        (await response.Content.ReadAsStringAsync())
             .Should()
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:or\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
@@ -307,12 +307,12 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             });
 
         // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
+        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
 
         // Assert
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions).ConfigureAwait(false);
+        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
         error!.Errors.Should().ContainSingle().And.Satisfy(
             x => x.Value.Single() == "Keys FrameworkAgreement.traceability have been defined multiple times");
     }
@@ -325,7 +325,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     public async Task CheckSwagger_ReturnsExpected()
     {
         // Act
-        var response = await _client.GetAsync($"{BaseUrl}/swagger/v2/swagger.json").ConfigureAwait(false);
+        var response = await _client.GetAsync($"{BaseUrl}/swagger/v2/swagger.json");
 
         // Assert
         response.Should().NotBeNull();

--- a/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
+++ b/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Service.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Service.Tests</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -35,18 +35,18 @@
     <PackageReference Include="AutoFixture" Version="4.18.0" />
     <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
-    <PackageReference Include="FakeItEasy" Version="7.4.0" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.10" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.4.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="FakeItEasy" Version="8.1.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION

## Description

* upgrade nuget packages
* remove configureAwait from unit tests

## Why

Since .NET 7 is only supported until May 14, 2024 the portal services and jobs are upgraded to .NET 8 which is an LTS version

## Issue

Refs: #19

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)