### PR TITLE
feat(template): policyhub template update

### DIFF
--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -112,6 +112,11 @@ public class PolicyHubBusinessLogic : IPolicyHubBusinessLogic
 
     public async Task<PolicyResponse> GetPolicyContentAsync(PolicyContentRequest requestData)
     {
+        if (requestData.PolicyType == PolicyTypeId.Usage && requestData.ConstraintOperand == ConstraintOperandId.Or)
+        {
+            throw new ControllerArgumentException($"The support of OR constraintOperand for Usage constraints are not supported for now");
+        }
+
         var keyCounts = requestData.Constraints
             .GroupBy(pair => pair.Key)
             .ToDictionary(group => group.Key, group => group.Count());

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -276,6 +276,25 @@ public class PolicyHubBusinessLogicTests
     }
 
     [Fact]
+    public async Task GetPolicyContentAsync_WithUsageConstraintNotAllowedWithOR_ThrowsControllerArgumentException()
+    {
+        // Arrange
+        var data = new PolicyContentRequest(PolicyTypeId.Usage, ConstraintOperandId.Or,
+            new[]
+            {
+                new Constraints("test", OperatorId.Equals, "testRegValue"),
+            });
+
+        async Task Act() => await _sut.GetPolicyContentAsync(data);
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+
+        // Assert
+        ex.Message.Should().Be(@"The support of OR constraintOperand for Usage constraints are not supported for now");
+    }
+
+    [Fact]
     public async Task GetPolicyContentAsync_WithMultipleDefinedKeys_ThrowsNotFoundException()
     {
         // Arrange

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -288,7 +288,7 @@ public class PolicyHubBusinessLogicTests
         async Task Act() => await _sut.GetPolicyContentAsync(data);
 
         // Act
-        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act).ConfigureAwait(false);
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
         ex.Message.Should().Be(@"The support of OR constraintOperand for Usage constraints are not supported for now");

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -269,53 +269,53 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
     }
 
-    [Fact]
-    public async Task GetPolicyContentWithFiltersAsync_MultipleConstraintsEqualsOrOperand_ReturnsExpected()
-    {
-        // Arrange
-        var data = new PolicyContentRequest(
-            PolicyTypeId.Usage,
-            ConstraintOperandId.Or,
-            new[]
-            {
-                new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
-                new Constraints("companyRole.dismantler", OperatorId.In, null),
-            });
+    // [Fact]
+    // public async Task GetPolicyContentWithFiltersAsync_MultipleConstraintsEqualsOrOperand_ReturnsExpected()
+    // {
+    //     // Arrange
+    //     var data = new PolicyContentRequest(
+    //         PolicyTypeId.Usage,
+    //         ConstraintOperandId.Or,
+    //         new[]
+    //         {
+    //             new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
+    //             new Constraints("companyRole.dismantler", OperatorId.In, null),
+    //         });
 
-        // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
+    //     // Act
+    //     var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
 
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync())
-            .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:or\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
-    }
+    //     // Assert
+    //     response.Should().NotBeNull();
+    //     response.StatusCode.Should().Be(HttpStatusCode.OK);
+    //     (await response.Content.ReadAsStringAsync().ConfigureAwait(false))
+    //         .Should()
+    //         .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:or\":[{\"leftOperand\":\"FrameworkAgreement.traceability\",\"operator\":\"eq\",\"rightOperand\":\"@FrameworkAgreement.traceability-Version\"},{\"leftOperand\":\"Dismantler.activityType\",\"operator\":\"in\",\"rightOperand\":[\"Audi\",\"BMW\",\"VW\"]}]}}},\"attributes\":[{\"key\":\"@FrameworkAgreement.traceability-Version\",\"possibleValues\":[\"active:1.0\",\"active:1.1\",\"active:1.2\"]}]}");
+    // }
 
-    [Fact]
-    public async Task GetPolicyContentWithFiltersAsync_WithSameConstraintKeys_ReturnsError()
-    {
-        // Arrange
-        var data = new PolicyContentRequest(
-            PolicyTypeId.Usage,
-            ConstraintOperandId.Or,
-            new[]
-            {
-                new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
-                new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
-            });
+    // [Fact]
+    // public async Task GetPolicyContentWithFiltersAsync_WithSameConstraintKeys_ReturnsError()
+    // {
+    //     // Arrange
+    //     var data = new PolicyContentRequest(
+    //         PolicyTypeId.Usage,
+    //         ConstraintOperandId.Or,
+    //         new[]
+    //         {
+    //             new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
+    //             new Constraints("FrameworkAgreement.traceability", OperatorId.Equals, null),
+    //         });
 
-        // Act
-        var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions);
+    //     // Act
+    //     var response = await _client.PostAsJsonAsync($"{BaseUrl}/policy-content", data, JsonOptions).ConfigureAwait(false);
 
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
-        var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
-        error!.Errors.Should().ContainSingle().And.Satisfy(
-            x => x.Value.Single() == "Keys FrameworkAgreement.traceability have been defined multiple times");
-    }
+    //     // Assert
+    //     response.Should().NotBeNull();
+    //     response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    //     var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions).ConfigureAwait(false);
+    //     error!.Errors.Should().ContainSingle().And.Satisfy(
+    //         x => x.Value.Single() == "Keys FrameworkAgreement.traceability have been defined multiple times");
+    // }
 
     #endregion
 


### PR DESCRIPTION
## Description

Update the policy hub used policy template for the endpoint.
POST /api/policy-hub/policy-content endpoint:

## Why

Additionally to the generic structure - the support of "OR" constraintOperand for usage constraints are not supported for now.
Since this is in general allowed but not used by catena-x; i suggest instead of deleting the code to comment out the option to set an "OR" connection.
Note: access policies with an "OR" connection are still allowed (as shared above).

## Issue

#43 

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)