### PR TITLE
build(migrations): merge all migrations since the last release

### DIFF
--- a/src/database/PolicyHub.Migrations/Migrations/20240430122950_1.0.0-rc.1.Designer.cs
+++ b/src/database/PolicyHub.Migrations/Migrations/20240430122950_1.0.0-rc.1.Designer.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************
+/********************************************************************************
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -31,8 +31,8 @@ using Org.Eclipse.TractusX.PolicyHub.Entities;
 namespace Org.Eclipse.TractusX.PolicyHub.Migrations.Migrations
 {
     [DbContext(typeof(PolicyHubContext))]
-    [Migration("20240425103233_25-policy-seeding")]
-    partial class _25policyseeding
+    [Migration("20240430122950_1.0.0-rc.1")]
+    partial class _100rc1
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)

--- a/src/database/PolicyHub.Migrations/Migrations/20240430122950_1.0.0-rc.1.cs
+++ b/src/database/PolicyHub.Migrations/Migrations/20240430122950_1.0.0-rc.1.cs
@@ -25,7 +25,7 @@ using System;
 namespace Org.Eclipse.TractusX.PolicyHub.Migrations.Migrations
 {
     /// <inheritdoc />
-    public partial class _25policyseeding : Migration
+    public partial class _100rc1 : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/src/database/PolicyHub.Migrations/Migrations/PolicyHubContextModelSnapshot.cs
+++ b/src/database/PolicyHub.Migrations/Migrations/PolicyHubContextModelSnapshot.cs
@@ -1,4 +1,4 @@
-﻿/********************************************************************************
+/********************************************************************************
  * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional


### PR DESCRIPTION
## Description

Merge all migrations since the last release into one migration

## Why

To have one consolidated migration

## Issue

https://github.com/eclipse-tractusx/policy-hub/issues/59

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)