### PR TITLE
fix(policy): unexpected response for purpose attributekey id update is done

### DIFF
--- a/src/database/PolicyHub.Migrations/Seeder/BatchUpdateSeeder.cs
+++ b/src/database/PolicyHub.Migrations/Seeder/BatchUpdateSeeder.cs
@@ -63,12 +63,13 @@ public class BatchUpdateSeeder : ICustomSeeder
         await SeedTable<Policy>(
             "policies",
             x => new { x.Id },
-            x => x.dbEntity.IsActive != x.dataEntity.IsActive || x.dbEntity.TechnicalKey != x.dataEntity.TechnicalKey || x.dbEntity.LeftOperandValue != x.dataEntity.LeftOperandValue,
+            x => x.dbEntity.IsActive != x.dataEntity.IsActive || x.dbEntity.TechnicalKey != x.dataEntity.TechnicalKey || x.dbEntity.LeftOperandValue != x.dataEntity.LeftOperandValue || x.dbEntity.AttributeKeyId != x.dataEntity.AttributeKeyId,
             (dbEntity, entity) =>
             {
                 dbEntity.IsActive = entity.IsActive;
                 dbEntity.TechnicalKey = entity.TechnicalKey;
                 dbEntity.LeftOperandValue = entity.LeftOperandValue;
+                dbEntity.AttributeKeyId = entity.AttributeKeyId;
             }, cancellationToken).ConfigureAwait(false);
 
         await SeedTable<PolicyAttribute>(

--- a/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
+++ b/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
@@ -30,7 +30,7 @@
     "technical_key": "UsagePurpose",
     "description": "",
     "is_active": true,
-    "attribute_key_id": 3
+    "attribute_key_id": 2
   },
   {
     "id": "01a0fba3-9b6e-435a-b045-e0e890c300c9",


### PR DESCRIPTION
## Description

When the tester provides an input value that is not supported for the specified purposes, the endpoint should generate an error.

## Why

Changes for purpose key is implemented as per description along with changes in AttributeKeyId in db.

## Issue

##68

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)