### PR TITLE
docs: fix README docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the backend code for the Policy-Hub written in C#.
 
-For **information about the policy hub**, please refer to the documentation, especially the context and scope section in the [architecture documentation](./docs/architecture).
+For **information about the policy hub**, please refer to the documentation, especially the context and scope section in the [architecture documentation](./docs/technical-documentation/architecture).
 
 For **installation** details, please refer to the [README.md](./charts/policy-hub/README.md) of the provided helm chart.
 


### PR DESCRIPTION
This PR fixes the broken link to the documentation in the README.