### PR TITLE
chore(dependencies): bump efcore to 8.0.7

### DIFF
--- a/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
+++ b/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.0.0" />
     <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
   </ItemGroup>

--- a/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
+++ b/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
+++ b/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
@@ -33,7 +33,7 @@
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
+++ b/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
     <PackageReference Include="xunit" Version="2.7.0" />


### PR DESCRIPTION
## Description

increase efcore version to latest 8.0.7

## Why

efcore 8.0.3 has transitive dependency System.Text.Json 8.0.0 which has a security-vulerability that is clasified as high. Upgrade to efcore 8.0.7 implicitly upgrades this dependency to System.Text.Json 8.0.4 which resolves the vulnerability.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes