### PR TITLE
chore(helm): create same database schema as migrations

### DIFF
--- a/charts/policy-hub/templates/configmap-postgres-init.yaml
+++ b/charts/policy-hub/templates/configmap-postgres-init.yaml
@@ -27,8 +27,8 @@ metadata:
     {{- include "phub.labels" . | nindent 4 }}
 data:
   02-init-db.sql: |
-    CREATE SCHEMA hub;
-    ALTER SCHEMA hub OWNER TO hub;
+    CREATE SCHEMA policy-hub;
+    ALTER SCHEMA policy-hub OWNER TO hub;
     CREATE TABLE public.__efmigrations_history_hub (
         migration_id character varying(150) NOT NULL,
         product_version character varying(32) NOT NULL


### PR DESCRIPTION
## Description

schema used by the database migrations is "policy-hub" https://github.com/eclipse-tractusx/policy-hub/blob/v1.1.0-rc.1/src/database/PolicyHub.Entities/PolicyHubContext.cs#L55 and this inconsistency lead to the creation of one "hub" unused schema

## Why

don't create irrelevant schema

## Issue

na

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed a self-review of my own changes