### PR TITLE
chore(dependencies): enforce System.Text.Json version 8.0.4

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,8 +1,5 @@
-nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.18.0, MIT, approved, #10064
 nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.18.1, MIT, approved, #10064
-nuget/nuget/-/AutoFixture.Xunit/4.18.0, MIT, approved, #10082
 nuget/nuget/-/AutoFixture.Xunit/4.18.1, MIT, approved, #10082
-nuget/nuget/-/AutoFixture/4.18.0, MIT, approved, #10057
 nuget/nuget/-/AutoFixture/4.18.1, MIT, approved, #10057
 nuget/nuget/-/BouncyCastle.Cryptography/2.2.1, MIT AND Apache-2.0 AND BSD-3-Clause AND LicenseRef-Permission-Notice, approved, #10066
 nuget/nuget/-/Castle.Core/5.1.1, Apache-2.0, approved, #13966
@@ -28,7 +25,7 @@ nuget/nuget/-/Serilog.Enrichers.Thread/3.1.0, Apache-2.0, approved, clearlydefin
 nuget/nuget/-/Serilog.Extensions.Hosting/8.0.0, Apache-2.0, approved, #13962
 nuget/nuget/-/Serilog.Extensions.Logging/8.0.0, Apache-2.0, approved, #13985
 nuget/nuget/-/Serilog.Formatting.Compact/2.0.0, Apache-2.0, approved, #13981
-nuget/nuget/-/Serilog.Settings.Configuration/8.0.0, Apache-2.0, approved, #13988
+nuget/nuget/-/Serilog.Settings.Configuration/8.0.2, Apache-2.0, approved, #13988
 nuget/nuget/-/Serilog.Sinks.Console/5.0.1, Apache-2.0, approved, #13980
 nuget/nuget/-/Serilog.Sinks.Debug/2.0.0, Apache-2.0, approved, clearlydefined
 nuget/nuget/-/Serilog.Sinks.File/5.0.0, Apache-2.0, approved, #11116

--- a/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
+++ b/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.7" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.4.2" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.4.2" />
   </ItemGroup>
 
 </Project>

--- a/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
+++ b/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
@@ -45,9 +45,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.4.2" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/database/PolicyHub.Migrations/Program.cs
+++ b/src/database/PolicyHub.Migrations/Program.cs
@@ -54,5 +54,5 @@ catch (Exception ex) when (!ex.GetType().Name.Equals("StopTheHostException", Str
 finally
 {
     Log.Information("Process Shutting down...");
-    Log.CloseAndFlush();
+    await Log.CloseAndFlushAsync().ConfigureAwait(false);
 }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -20,12 +20,10 @@
 using Org.Eclipse.TractusX.PolicyHub.DbAccess;
 using Org.Eclipse.TractusX.PolicyHub.DbAccess.Models;
 using Org.Eclipse.TractusX.PolicyHub.DbAccess.Repositories;
-using Org.Eclipse.TractusX.PolicyHub.Entities.Entities;
 using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.Extensions;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
-using Org.Eclipse.TractusX.Portal.Backend.Framework.Linq;
 using System.Text.RegularExpressions;
 
 namespace Org.Eclipse.TractusX.PolicyHub.Service.BusinessLogic;
@@ -68,10 +66,10 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             _ => operatorId == OperatorId.Equals
                 ? rightOperands.Count() > 1 ?
                     ($"@{leftOperand}{(useCase != null ?
-                        useCase.ToString().Insert(0, ".") :
+                        useCase.Value.ToString().Insert(0, ".") :
                         string.Empty)}-{attributes.Key}",
                         new AdditionalAttributes($"@{leftOperand}{(useCase != null ?
-                            useCase.ToString().Insert(0, ".") :
+                            useCase.Value.ToString().Insert(0, ".") :
                             string.Empty)}-{attributes.Key}", rightOperands)) :
                     (rightOperands.Single(), null)
                 : (rightOperands, null)

--- a/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
+++ b/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Flurl.Signed" Version="3.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.4.2" />
     <PackageReference Include="System.Json" Version="4.7.1" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/hub/PolicyHub.Service/Program.cs
+++ b/src/hub/PolicyHub.Service/Program.cs
@@ -26,8 +26,8 @@ using System.Text.Json.Serialization;
 
 const string Version = "v2";
 
-WebApplicationBuildRunner
-    .BuildAndRunWebApplication<Program>(args, "policy-hub", Version, ".Hub",
+await WebApplicationBuildRunner
+    .BuildAndRunWebApplicationAsync<Program>(args, "policy-hub", Version, ".Hub",
         builder =>
         {
             builder.Services.AddTransient<IClaimsTransformation, KeycloakClaimsTransformation>();
@@ -47,4 +47,4 @@ WebApplicationBuildRunner
             app.MapGroup("/api")
                 .WithOpenApi()
                 .MapPolicyHubApi();
-        });
+        }).ConfigureAwait(ConfigureAwaitOptions.None);

--- a/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
+++ b/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
@@ -32,12 +32,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.7.0" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">

--- a/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
+++ b/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.0" />
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.0" />
+    <PackageReference Include="AutoFixture" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.AutoFakeItEasy" Version="4.18.1" />
+    <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />


### PR DESCRIPTION
## Description

framework version updated to 2.4.2
fix codeql-findings (nullable and use of async in program.cs)

## Why

frameworks was referencing outdated System.Text.Json 8.0.0 which has a vulnerability-issue that must be fixed. Upgrading to frameworks 2.4.2 implicitly resolves this outdated dependency.

## Issue

https://github.com/eclipse-tractusx/portal/issues/369

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes