### PR TITLE
feat: add imagePullSecrets

### DIFF
--- a/charts/policy-hub/templates/deployment-hub.yaml
+++ b/charts/policy-hub/templates/deployment-hub.yaml
@@ -36,6 +36,10 @@ spec:
       labels:
         {{- include "phub.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.service.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ include "phub.fullname" . }}
         securityContext:

--- a/charts/policy-hub/values.yaml
+++ b/charts/policy-hub/values.yaml
@@ -21,6 +21,7 @@ service:
   image:
     name: "docker.io/tractusx/policy-hub-service"
     tag: ""
+    pullSecrets: []
   imagePullPolicy: "IfNotPresent"
   # -- We recommend to review the default resource limits as this should a conscious choice.
   resources:


### PR DESCRIPTION
## Description

The imagePullSecrets field allows you to specify secrets needed to pull Docker images from private repositories.
[Request](https://github.com/eclipse-tractusx/portal/pull/396#issuecomment-2269640289) by @evegufy 

## Why

In many organizations, container images are stored in private registries rather than public ones for security and compliance reasons. To pull these images, Kubernetes needs credentials, which are provided via imagePullSecrets. This code dynamically includes the necessary secrets for pulling images, based on the configuration provided in the Helm chart's values file.

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have checked that new and existing tests pass locally with my changes