### PR TITLE
fix: policy hub  post get policy rules response structuring error value map

### DIFF
--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -76,7 +76,7 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             {
                 throw new ControllerArgumentException($"Invalid values [{value}] set for key {leftOperand}. Possible values [{string.Join(",", rightOperands.Select(x => x))}]");
             }
-            rightOperands = rightOperands.Select(r => r).Where(r => r.Equals(value));
+            rightOperands = rightOperands.Where(r => r.Equals(value));
         }
         return rightOperands.Count() > 1 ?
                     ($"@{leftOperand}{(useCase != null ?

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -74,7 +74,7 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         {
             if (!rightOperands.Any(r => r == value))
             {
-                throw new ControllerArgumentException($"Invalid values [{value}] set for key {leftOperand}. Possible values [{string.Join(",", rightOperands.Select(x => x))}]");
+                throw new ControllerArgumentException($"Invalid values [{value}] set for key {leftOperand}. Possible values [{string.Join(",", rightOperands)}]");
             }
             rightOperands = rightOperands.Where(r => r.Equals(value));
         }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -78,13 +78,13 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             }
             rightOperands = rightOperands.Where(r => r.Equals(value));
         }
+
+        var useCaseValue = useCase != null ?
+            useCase.Value.ToString().Insert(0, ".") :
+            string.Empty;
+        var rightOperand = $"@{leftOperand}{useCaseValue}-{attributes.Key}";
         return rightOperands.Count() > 1 ?
-                    ($"@{leftOperand}{(useCase != null ?
-                        useCase.Value.ToString().Insert(0, ".") :
-                        string.Empty)}-{attributes.Key}",
-                        new AdditionalAttributes($"@{leftOperand}{(useCase != null ?
-                            useCase.Value.ToString().Insert(0, ".") :
-                            string.Empty)}-{attributes.Key}", rightOperands)) :
+                    (rightOperand, new AdditionalAttributes(rightOperand, rightOperands)) :
                     (rightOperands.Single(), null);
     }
 

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -64,16 +64,29 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             AttributeKeyId.DynamicValue => (value ?? "{dynamicValue}", null),
             AttributeKeyId.Regex => (GetRegexValue(attributes, value), null),
             _ => operatorId == OperatorId.Equals
-                ? rightOperands.Count() > 1 ?
+                ? processEqualsOperator(attributes, rightOperands, value, leftOperand, useCase)
+                : (rightOperands, null)
+        };
+
+    private static (object rightOperand, AdditionalAttributes? additionalAttribute) processEqualsOperator((AttributeKeyId? Key, IEnumerable<string> Values) attributes, IEnumerable<string> rightOperands, string? value, string leftOperand, UseCaseId? useCase)
+    {
+        if (value != null)
+        {
+            if (!rightOperands.Any(r => r == value))
+            {
+                throw new ControllerArgumentException($"Invalid values [{value}] set for key {leftOperand}. Possible values [{string.Join(",", rightOperands.Select(x => x))}]");
+            }
+            rightOperands = rightOperands.Select(r => r).Where(r => r.Equals(value));
+        }
+        return rightOperands.Count() > 1 ?
                     ($"@{leftOperand}{(useCase != null ?
                         useCase.Value.ToString().Insert(0, ".") :
                         string.Empty)}-{attributes.Key}",
                         new AdditionalAttributes($"@{leftOperand}{(useCase != null ?
                             useCase.Value.ToString().Insert(0, ".") :
                             string.Empty)}-{attributes.Key}", rightOperands)) :
-                    (rightOperands.Single(), null)
-                : (rightOperands, null)
-        };
+                    (rightOperands.Single(), null);
+    }
 
     private static object GetRegexValue((AttributeKeyId? Key, IEnumerable<string> Values) attributes, string? value)
     {
@@ -163,7 +176,7 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         if (invalidValues.Any())
         {
             var x = missingValues.Where(x => invalidValues.Contains(x.TechnicalKey)).Select(x =>
-                $"Key: {x.TechnicalKey}, invalid values: {string.Join(',', x.Values)}");
+                $"Key: {x.TechnicalKey}, requested value[{string.Join(',', x.Values)}] Possible Values[{string.Join(',', attributeValuesForTechnicalKeys.Where(a => a.TechnicalKey.Equals(x.TechnicalKey)).Select(a => a.Values.Select(x => x)).First())}]");
             throw new ControllerArgumentException($"Invalid values set for {string.Join(',', x)}");
         }
 

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -176,7 +176,7 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         if (invalidValues.Any())
         {
             var x = missingValues.Where(x => invalidValues.Contains(x.TechnicalKey)).Select(x =>
-                $"Key: {x.TechnicalKey}, requested value[{string.Join(',', x.Values)}] Possible Values[{string.Join(',', attributeValuesForTechnicalKeys.Where(a => a.TechnicalKey.Equals(x.TechnicalKey)).Select(a => a.Values.Select(x => x)).First())}]");
+                $"Key: {x.TechnicalKey}, requested value[{string.Join(',', x.Values)}] Possible Values[{string.Join(',', attributeValuesForTechnicalKeys.Where(a => a.TechnicalKey.Equals(x.TechnicalKey)).Select(a => a.Values).First())}]");
             throw new ControllerArgumentException($"Invalid values set for {string.Join(',', x)}");
         }
 

--- a/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
+++ b/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
@@ -23,6 +23,7 @@ using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.BusinessLogic;
 using Org.Eclipse.TractusX.PolicyHub.Service.Extensions;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
 using System.Diagnostics.CodeAnalysis;
 
@@ -81,7 +82,8 @@ public static class PolicyHubController
             .RequireAuthorization()
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(PolicyResponse), Constants.JsonContentType)
-            .Produces(StatusCodes.Status404NotFound, typeof(ErrorResponse), Constants.JsonContentType);
+            .Produces(StatusCodes.Status400BadRequest, typeof(ErrorResponse), Constants.JsonContentType)
+            .Produces(StatusCodes.Status404NotFound, typeof(ControllerArgumentException), Constants.JsonContentType);
 
         return group;
     }

--- a/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
+++ b/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
@@ -71,6 +71,7 @@ public static class PolicyHubController
             .RequireAuthorization()
             .WithDefaultResponses()
             .Produces(StatusCodes.Status200OK, typeof(PolicyResponse), Constants.JsonContentType)
+            .Produces(StatusCodes.Status400BadRequest, typeof(ErrorResponse), Constants.JsonContentType)
             .Produces(StatusCodes.Status404NotFound, typeof(ErrorResponse), Constants.JsonContentType);
 
         policyHub.MapPost("policy-content", ([FromBody] PolicyContentRequest requestData, IPolicyHubBusinessLogic logic) => logic.GetPolicyContentAsync(requestData))

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -169,7 +169,7 @@ public class PolicyHubBusinessLogicTests
             .Returns(new ValueTuple<bool, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>(true, "multipleAdditionalValues", new ValueTuple<AttributeKeyId, IEnumerable<string>>(AttributeKeyId.Static, new[] { "value1", "value2", "value3" }), null));
 
         // Act
-        var result = await _sut.GetPolicyContentWithFiltersAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues", OperatorId.Equals, "test");
+        var result = await _sut.GetPolicyContentWithFiltersAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues", OperatorId.Equals, null);
 
         // Assert
         result.Content.Id.Should().Be("....");
@@ -186,6 +186,23 @@ public class PolicyHubBusinessLogicTests
         result.Content.Permission.Constraint.Operator.Should().Be("eq");
         result.Content.Permission.Constraint.AndOperands.Should().BeNull();
         result.Content.Permission.Constraint.OrOperands.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetPolicyContentWithFiltersAsync_WithInvalidValue_ExceptionExpected()
+    {
+        // Arrange
+        A.CallTo(() => _policyRepository.GetPolicyContentAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues"))
+            .Returns(new ValueTuple<bool, string, ValueTuple<AttributeKeyId?, IEnumerable<string>>, string?>(true, "multipleAdditionalValues", new ValueTuple<AttributeKeyId, IEnumerable<string>>(AttributeKeyId.Static, new[] { "value1", "value2", "value3" }), null));
+
+        // Act
+        async Task Act() => await _sut.GetPolicyContentWithFiltersAsync(UseCaseId.Traceability, PolicyTypeId.Usage, "multipleAdditionalValues", OperatorId.Equals, "test");
+
+        // Act
+        var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
+
+        // Assert
+        ex.Message.Should().Be("Invalid values [test] set for key multipleAdditionalValues. Possible values [value1,value2,value3]");
     }
 
     #endregion
@@ -264,7 +281,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("Invalid values set for Key: test, invalid values: abc");
+        ex.Message.Should().Be("Invalid values set for Key: test, requested value[abc] Possible Values[test]");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Enhanced the filter GET/POST for policyContent end point

## Why

The current implementation of the GET/POST endpoint in the Policy Hub does not respond as expected when fetching a policy based on specific criteria

## Issue

N/a

## Checklist

Please delete options that are not relevant.

- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
