### PR TITLE
fix: update incorrect seeding data and not supported policies

### DIFF
--- a/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
+++ b/src/database/PolicyHub.Migrations/Seeder/Data/policies.json
@@ -21,7 +21,7 @@
     "kind_id": 5,
     "technical_key": "Dismantler.allowedBrands",
     "description": "Company role defining a dismantler. Companies holding the credential are dismantler certified companies.",
-    "is_active": true,
+    "is_active": false,
     "attribute_key_id": 4
   },
   {
@@ -45,7 +45,7 @@
     "kind_id": 5,
     "technical_key": "Dismantler",
     "description": "Companies holding the credential are dismantler certified companies.",
-    "is_active": true,
+    "is_active": false,
     "attribute_key_id": 4
   },
   {

--- a/src/database/PolicyHub.Migrations/Seeder/Data/policy_attributes.json
+++ b/src/database/PolicyHub.Migrations/Seeder/Data/policy_attributes.json
@@ -207,21 +207,21 @@
     "policy_id": "01a0fba3-9b6e-435a-b045-e0e890c300c1",
     "key": 4,
     "attribute_value": "BMW",
-    "is_active": true
+    "is_active": false
   },
   {
     "id": "01a0fba3-9b6e-435a-b045-e0e890c300d7",
     "policy_id": "01a0fba3-9b6e-435a-b045-e0e890c300c1",
     "key": 4,
     "attribute_value": "Audi",
-    "is_active": true
+    "is_active": false
   },
   {
     "id": "01a0fba3-9b6e-435a-b045-e0e890c300d8",
     "policy_id": "01a0fba3-9b6e-435a-b045-e0e890c300c1",
     "key": 4,
     "attribute_value": "VW",
-    "is_active": true
+    "is_active": false
   },
   {
     "id": "d72611ad-b6e4-47cc-94d2-d3efdc02db17",
@@ -235,7 +235,7 @@
     "policy_id": "01a0fba3-9b6e-435a-b045-e0e890c300d1",
     "key": 4,
     "attribute_value": "active",
-    "is_active": true
+    "is_active": false
   },
   {
     "id": "01a0fba3-9b6e-435a-b045-e0e890c30030",

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyRepositoryTests.cs
@@ -72,13 +72,11 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetPolicyTypes(null, null).ToListAsync();
 
         // Assert
-        result.Should().NotBeEmpty().And.HaveCount(7).And.Satisfy(
+        result.Should().NotBeEmpty().And.HaveCount(5).And.Satisfy(
             x => x.TechnicalKey == "BusinessPartnerNumber",
             x => x.TechnicalKey == "Membership",
             x => x.TechnicalKey == "FrameworkAgreement",
-            x => x.TechnicalKey == "Dismantler.allowedBrands",
             x => x.TechnicalKey == "UsagePurpose",
-            x => x.TechnicalKey == "Dismantler",
             x => x.TechnicalKey == "ContractReference"
         );
     }
@@ -93,11 +91,9 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetPolicyTypes(PolicyTypeId.Access, null).ToListAsync();
 
         // Assert
-        result.Should().NotBeEmpty().And.HaveCount(4).And.Satisfy(
+        result.Should().NotBeEmpty().And.HaveCount(2).And.Satisfy(
             x => x.TechnicalKey == "BusinessPartnerNumber" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "Membership" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "Dismantler.allowedBrands" && x.Attribute.Count() == 3 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "Dismantler" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5
+            x => x.TechnicalKey == "Membership" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5
         );
     }
 
@@ -111,12 +107,10 @@ public class PolicyRepositoryTests : IAssemblyFixture<TestDbFixture>
         var result = await sut.GetPolicyTypes(null, UseCaseId.Quality).ToListAsync();
 
         // Assert
-        result.Should().NotBeEmpty().And.HaveCount(5).And.Satisfy(
+        result.Should().NotBeEmpty().And.HaveCount(3).And.Satisfy(
             x => x.TechnicalKey == "BusinessPartnerNumber" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
             x => x.TechnicalKey == "Membership" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "Dismantler.allowedBrands" && x.Attribute.Count() == 3 && x.Type.Count() == 2 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "FrameworkAgreement" && x.Attribute.Count() == 1 && x.Type.Count() == 1 && x.UseCase.Count() == 5,
-            x => x.TechnicalKey == "Dismantler" && x.Attribute.Count() == 1 && x.Type.Count() == 2 && x.UseCase.Count() == 5
+            x => x.TechnicalKey == "FrameworkAgreement" && x.Attribute.Count() == 1 && x.Type.Count() == 1 && x.UseCase.Count() == 5
         );
     }
 

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -78,13 +78,11 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
 
         // Assert
         policies.Should().NotBeNull()
-            .And.HaveCount(7).And.Satisfy(
+            .And.HaveCount(5).And.Satisfy(
                 x => x.TechnicalKey == "BusinessPartnerNumber",
                 x => x.TechnicalKey == "Membership",
                 x => x.TechnicalKey == "FrameworkAgreement",
-                x => x.TechnicalKey == "Dismantler.allowedBrands",
                 x => x.TechnicalKey == "UsagePurpose",
-                x => x.TechnicalKey == "Dismantler",
                 x => x.TechnicalKey == "ContractReference"
             );
     }
@@ -97,11 +95,9 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
 
         // Assert
         policies.Should().NotBeNull()
-            .And.HaveCount(4).And.Satisfy(
+            .And.HaveCount(2).And.Satisfy(
                 x => x.TechnicalKey == "BusinessPartnerNumber",
-                x => x.TechnicalKey == "Membership",
-                x => x.TechnicalKey == "Dismantler.allowedBrands",
-                x => x.TechnicalKey == "Dismantler"
+                x => x.TechnicalKey == "Membership"
             );
     }
 
@@ -113,13 +109,11 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
 
         // Assert
         policies.Should().NotBeNull()
-            .And.HaveCount(6).And.Satisfy(
+            .And.HaveCount(4).And.Satisfy(
                 x => x.TechnicalKey == "BusinessPartnerNumber",
                 x => x.TechnicalKey == "Membership",
                 x => x.TechnicalKey == "FrameworkAgreement",
-                x => x.TechnicalKey == "Dismantler.allowedBrands",
-                x => x.TechnicalKey == "UsagePurpose",
-                x => x.TechnicalKey == "Dismantler"
+                x => x.TechnicalKey == "UsagePurpose"
             );
     }
 
@@ -184,17 +178,14 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     }
 
     [Fact]
-    public async Task GetPolicyContent_UsageDismantlerIn_ReturnsExpected()
+    public async Task GetPolicyContent_UsageDismantlerIn_ExceptionExpected()
     {
         // Act
         var response = await _client.GetAsync($"{BaseUrl}/policy-content?type={PolicyTypeId.Usage}&policyName=Dismantler.allowedBrands&operatorType={OperatorId.In}");
 
         // Assert
         response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync())
-            .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Dismantler.allowedBrands\",\"operator\":\"in\",\"rightOperand\":[\"BMW\",\"Audi\",\"VW\"]}}}}");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact]
@@ -225,7 +216,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             new[]
             {
                 new Constraints("FrameworkAgreement", OperatorId.Equals, "DataExchangeGovernance:1.0"),
-                new Constraints("Dismantler.allowedBrands", OperatorId.In, "Audi")
+                new Constraints("UsagePurpose", OperatorId.In, "cx.bpdm.pool:1")
             });
 
         // Act
@@ -236,7 +227,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:Dismantler.allowedBrands\",\"operator\":\"in\",\"rightOperand\":[\"BMW\",\"Audi\",\"VW\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:UsagePurpose\",\"operator\":\"in\",\"rightOperand\":[\"cx.circular.dpp:1\",\"cx.circular.smc:1\",\"cx.circular.marketplace:1\",\"cx.circular.materialaccounting:1\",\"cx.bpdm.gate.upload:1\",\"cx.bpdm.gate.download:1\",\"cx.bpdm.pool:1\",\"cx.bpdm.vas.dataquality.upload:1\",\"cx.bpdm.vas.dataquality.download:1\",\"cx.bpdm.vas.bdv.upload:1\",\"cx.bpdm.vas.bdv.download:1\",\"cx.bpdm.vas.fpd.upload:1\",\"cx.bpdm.vas.fpd.download:1\",\"cx.bpdm.vas.swd.upload:1\",\"cx.bpdm.vas.swd.download:1\",\"cx.bpdm.vas.nps.upload:1\",\"cx.bpdm.vas.nps.download:1\",\"cx.bpdm.vas.countryrisk:1\",\"cx.behaviortwin.base:1\",\"cx.core.digitalTwinRegistry:1\",\"cx.core.tractionbattery:1\",\"cx.core.industrycore:1\",\"cx.core.qualityNotifications:1\",\"cx.pcf.base:1\",\"cx.quality.base:1\",\"cx.dcm.base:1\",\"cx.puris.base:1\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     [Fact]
@@ -270,7 +261,6 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
             new[]
             {
                 new Constraints("FrameworkAgreement", OperatorId.Equals, "DataExchangeGovernance:1.0"),
-                new Constraints("Dismantler.allowedBrands", OperatorId.In, "Audi"),
                 new Constraints("BusinessPartnerNumber", OperatorId.Equals, "BPNL00000003CRHK")
             });
 
@@ -282,7 +272,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:Dismantler.allowedBrands\",\"operator\":\"in\",\"rightOperand\":[\"BMW\",\"Audi\",\"VW\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     #endregion


### PR DESCRIPTION
## Description

update incorrect seeding data and not supported policies

## Why

The current seeding image has a number of incorrect/not supported policies.

## Issue

Na

## Checklist

Please delete options that are not relevant.

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
