### PR TITLE
build: add stable env configuration file

### DIFF
--- a/environments/argocd-app-templates/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/appsetup-stable.yaml
@@ -1,0 +1,38 @@
+###############################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: policy-hub
+spec:
+  destination:
+    namespace: product-portal
+    server: 'https://kubernetes.default.svc'
+  source:
+    path: charts/policy-hub
+    repoURL: 'https://github.com/eclipse-tractusx/policy-hub.git'
+    targetRevision: policy-hub-1.1.0
+    plugin:
+      env:
+        - name: AVP_SECRET
+          value: vault-secret
+        - name: helm_args
+          value: '-f values.yaml -f ../../environments/helm-values/values-stable.yaml'
+  project: project-portal

--- a/environments/argocd-app-templates/appsetup-stable.yaml
+++ b/environments/argocd-app-templates/appsetup-stable.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -1,0 +1,62 @@
+###############################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+
+policyHubAddress: "https://policy-hub.stable.catena-x.net"
+centralidp:
+  address: "https://centralidp.stable.catena-x.net"
+
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    nginx.ingress.kubernetes.io/proxy-body-size: "8m"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "https://*.stable.catena-x.net"
+  tls:
+    - secretName: "policy-hub.stable.catena-x.net-tls"
+      hosts:
+        - "policy-hub.stable.catena-x.net"
+  hosts:
+    - host: "policy-hub.stable.catena-x.net"
+      paths:
+        - path: "/api/policy-hub"
+          pathType: "Prefix"
+
+keycloak:
+  central:
+    jwtBearerOptions:
+      tokenValidationParameters:
+        validAudience: "Cl23-CX-Policy-Hub"
+
+service:
+  swaggerEnabled: true
+
+migrations:
+  logging:
+    default: "Debug"
+
+replicaCount: 2
+
+postgresql:
+  architecture: standalone
+  auth:
+    postgrespassword: "<path:portal/data/policy-hub/stable/postgres#postgres-password>"
+    password: "<path:portal/data/policy-hub/stable/postgres#password>"

--- a/environments/helm-values/values-stable.yaml
+++ b/environments/helm-values/values-stable.yaml
@@ -1,5 +1,5 @@
 ###############################################################
-# Copyright (c) 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.


### PR DESCRIPTION
## Description

A new values.yaml for the stable configuration was added similar to values-int.yaml.

## Why

With the new stable environment a specific values.yaml is necessary for the deployment of the service. 

## Issue

Relates to https://github.com/eclipse-tractusx/portal/issues/408

## Checklist

Please delete options that are not relevant.

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/technical-documentation/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)