### PR TITLE
docs: add api hub to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ For **information about the policy hub**, please refer to the documentation, esp
 
 For **installation** details, please refer to the [README.md](./charts/policy-hub/README.md) of the provided helm chart.
 
+To see the latest open API specs you can have a look at the [API Hub](https://eclipse-tractusx.github.io/api-hub/policy-hub/).
+
 ## How to build and run
 
 Install the [.NET 8.0 SDK](https://www.microsoft.com/net/download).

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,12 +4,12 @@ This repository provides the backend code for the Policy Hub.
 
 The following table links you to the respective documentations.
 
-| Documentation                                                     | Purpose                                                                |
-| ----------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| [Arc42](architecture/Index.md)                                    | Architecture Documentation for the Policy Hub.                         |
-| [How to contribute](./admin/dev-process/How%20to%20contribute.md) | Information relevant, if you contribute in the policy hub development. |
-| [Administration Guide](admin/Admin_Guide.md)                      | Information relevant, if you want to use the policy hub application.   |
-| [API Documentation](api/API_Doc.md)                               | Information about the endpoints.                                       |
+| Documentation                                                                                           | Purpose                                                                |
+| ------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| [Arc42](architecture/Index.md)                                                                          | Architecture Documentation for the Policy Hub.                         |
+| [How to contribute](./admin/dev-process/How%20to%20contribute.md)                                       | Information relevant, if you contribute in the policy hub development. |
+| [Administration Guide](admin/Admin_Guide.md)                                                            | Information relevant, if you want to use the policy hub application.   |
+| [API Documentation](api/API_Doc.md) & [API Hub](https://eclipse-tractusx.github.io/api-hub/policy-hub/) | Information about the endpoints.                                       |
 
 ## NOTICE
 

--- a/docs/api/API_Doc.md
+++ b/docs/api/API_Doc.md
@@ -6,6 +6,10 @@ This document provides information on the endpoints.
 
 There is an [OpenAPI 3.0.1 specification document](./hub-service.yaml) available.
 
+## API Hub
+
+To see the latest open API specs you can have a look at the [API Hub](https://eclipse-tractusx.github.io/api-hub/policy-hub/).
+
 ## Postman
 
 There is a [postman collection](./postman) containing information on how to provide master data and some basic data to test the application.


### PR DESCRIPTION
## Description

Add API Hub links to the documentation

## Why

To have the api hub linked in the docs

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)