### PR TITLE
docs: fix how to contribute link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ https://www.eclipse.org/projects/handbook/#resources-commit
 
 ## How To Contribute
 
-For more practical information, please refer to [Contribution details](/docs/technical-documentation/dev-process/How%20to%20contribute.md).
+For more practical information, please refer to [Contribution details](/docs/admin/dev-process/How%20to%20contribute.md).
 
 ## Contact
 


### PR DESCRIPTION
## Description

Fix the "How to Contribute" link.

## Why

The existing link is broken.

## Issue

[Issue #483](https://github.com/eclipse-tractusx/portal/issues/483) 

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [X] I have successfully tested my changes locally