### PR TITLE
chore(net9): update version to net9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         language: ["csharp"]
+        dotnet-version: [ '9.0' ]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift' ]
         # Use only 'java' to analyze code written in Java, Kotlin or both
         # Use only 'javascript' to analyze code written in JavaScript, TypeScript or both
@@ -70,6 +71,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,7 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # change to preview .NET 9 until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8
         dotnet-version: ['9.0']
 
     steps:
@@ -47,8 +46,6 @@ jobs:
         uses: actions/setup-dotnet@3951f0dfe7a07e2313ec93c75700083e2005cbab # v4.3.0
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-          # change to preview .NET 9 until fix for https://github.com/NuGet/Home/issues/12954 gets released for .NET 8
-          dotnet-quality: 'preview'
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,10 +23,12 @@ on:
     branches: [main]
     paths:
       - 'src/**'
+      - 'tests/**'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - 'src/**'
+      - 'tests/**'
   workflow_dispatch:
 
 jobs:
@@ -36,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0']
+        dotnet-version: ['9.0']
 
     steps:
       - name: Set up JDK 17
@@ -47,6 +49,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@3e891b0cb619bf60e2c25674b222b8940e2c1c25 # v4.1.0
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test-automation.yml
+++ b/.github/workflows/test-automation.yml
@@ -29,7 +29,7 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     strategy:
       matrix:
-        dotnet-version: [ '8.0' ]
+        dotnet-version: [ '9.0' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/unit.tests-formatting.yml
+++ b/.github/workflows/unit.tests-formatting.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0']
+        dotnet-version: ['9.0']
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -49,7 +49,16 @@ jobs:
       - name: Install dependencies
         run: dotnet restore src
       - name: Build
-        run: dotnet build src --configuration Release --no-restore
+        run: dotnet build src --configuration Release --no-restore      
+      - name: Check for uncommitted files in working directory # refers to updated api specifications, please refer to /docs/api/README.md
+        run: |
+          git_status=$(git status --porcelain)
+          if [ -n "$git_status" ]; then
+            echo "Please commit the file(s) in your working directory after executing the build command"
+            exit 1
+          else
+            echo "No modified files found in the working directory."
+          fi
       - name: Check Format
         run: dotnet format src --verify-no-changes --no-restore
       - name: Test

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -2,36 +2,36 @@ nuget/nuget/-/AutoFixture.AutoFakeItEasy/4.18.1, MIT, approved, #10064
 nuget/nuget/-/AutoFixture.Xunit/4.18.1, MIT, approved, #10082
 nuget/nuget/-/AutoFixture/4.18.1, MIT, approved, #10057
 nuget/nuget/-/Castle.Core/5.1.1, Apache-2.0, approved, #13966
-nuget/nuget/-/EFCore.NamingConventions/8.0.3, Apache-2.0, approved, #13983
+nuget/nuget/-/EFCore.NamingConventions/9.0.0, Apache-2.0, approved, #17617
 nuget/nuget/-/FakeItEasy/8.3.0, MIT, approved, #16328
 nuget/nuget/-/Fare/2.1.1, MIT, approved, clearlydefined
 nuget/nuget/-/FluentAssertions/6.12.2, MIT AND Apache-2.0 AND BSD-3-Clause AND CC-BY-3.0-US AND (GPL-2.0-only OR MIT) AND OFL-1.1 AND WTFPL, approved, #13976
 nuget/nuget/-/Flurl.Signed/4.0.0, MIT, approved, #16448
 nuget/nuget/-/Humanizer.Core/2.14.1, MIT, approved, #10060
-nuget/nuget/-/Mono.TextTemplating/2.2.1, MIT, approved, #15073
+nuget/nuget/-/Mono.TextTemplating/3.0.0, MIT, approved, #17609
 nuget/nuget/-/Newtonsoft.Json/13.0.1, MIT AND BSD-3-Clause, approved, #3266
-nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/8.0.11, PostgreSQL AND MIT, approved, #13972
-nuget/nuget/-/Npgsql/8.0.6, PostgreSQL, approved, #13963
+nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/9.0.3, PostgreSQL AND MIT, approved, #17615
+nuget/nuget/-/Npgsql/9.0.2, PostgreSQL, approved, #17608
 nuget/nuget/-/SSH.NET/2024.1.0, MIT AND ISC AND LicenseRef-Public-domain AND (MIT AND MS-PL), approved, #17777
-nuget/nuget/-/Serilog.AspNetCore/8.0.3, Apache-2.0 AND MIT, approved, #13967
+nuget/nuget/-/Serilog.AspNetCore/9.0.0, Apache-2.0 AND MIT, approved, #19193
 nuget/nuget/-/Serilog.Enrichers.CorrelationId/3.0.1, MIT, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Environment/3.0.1, Apache-2.0, approved, #17052
 nuget/nuget/-/Serilog.Enrichers.Process/3.0.0, Apache-2.0, approved, #17053
 nuget/nuget/-/Serilog.Enrichers.Sensitive/1.7.3, MIT, approved, clearlydefined
 nuget/nuget/-/Serilog.Enrichers.Thread/4.0.0, Apache-2.0, approved, #17050
-nuget/nuget/-/Serilog.Extensions.Hosting/8.0.0, Apache-2.0, approved, #13962
-nuget/nuget/-/Serilog.Extensions.Logging/8.0.0, Apache-2.0, approved, #13985
-nuget/nuget/-/Serilog.Formatting.Compact/2.0.0, Apache-2.0, approved, #13981
-nuget/nuget/-/Serilog.Settings.Configuration/8.0.4, Apache-2.0, approved, #13988
+nuget/nuget/-/Serilog.Extensions.Hosting/9.0.0, Apache-2.0, approved, #19186
+nuget/nuget/-/Serilog.Extensions.Logging/9.0.0, Apache-2.0, approved, #19180
+nuget/nuget/-/Serilog.Formatting.Compact/3.0.0, Apache-2.0, approved, #19181
+nuget/nuget/-/Serilog.Settings.Configuration/9.0.0, Apache-2.0, approved, #19184
 nuget/nuget/-/Serilog.Sinks.Console/6.0.0, Apache-2.0, approved, #17054
-nuget/nuget/-/Serilog.Sinks.Debug/2.0.0, Apache-2.0, approved, clearlydefined
-nuget/nuget/-/Serilog.Sinks.File/5.0.0, Apache-2.0, approved, #11116
+nuget/nuget/-/Serilog.Sinks.Debug/3.0.0, Apache-2.0, approved, #19185
+nuget/nuget/-/Serilog.Sinks.File/6.0.0, Apache-2.0, approved, #19183
 nuget/nuget/-/Serilog/4.2.0, Apache-2.0, approved, #17774
 nuget/nuget/-/SharpZipLib/1.4.2, MIT AND GFDL-1.3-or-later AND (Apache-2.0 AND MIT) AND WTFPL AND bzip2-1.0.6 AND LicenseRef-Permissive-license-with-conditions AND LicenseRef-Permission-Notice, approved, #10058
-nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/6.9.0, MIT AND Apache-2.0, approved, #16817
-nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/6.9.0, MIT AND Apache-2.0, approved, #16820
-nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/6.9.0, MIT AND Apache-2.0, approved, #16818
-nuget/nuget/-/Swashbuckle.AspNetCore/6.9.0, MIT AND Apache-2.0, approved, #16816
+nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/7.2.0, MIT AND Apache-2.0, approved, #19189
+nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/7.2.0, MIT AND Apache-2.0, approved, #19190
+nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/7.2.0, MIT AND Apache-2.0, approved, #19191
+nuget/nuget/-/Swashbuckle.AspNetCore/7.2.0, MIT AND Apache-2.0, approved, #19182
 nuget/nuget/-/Testcontainers.PostgreSql/4.1.0, MIT, approved, #17771
 nuget/nuget/-/Testcontainers/4.1.0, MIT, approved, #17776
 nuget/nuget/-/Xunit.Extensions.AssemblyFixture/2.6.0, MIT, approved, #17055
@@ -42,5 +42,5 @@ nuget/nuget/-/xunit.assert/2.9.3, Apache-2.0, approved, #16331
 nuget/nuget/-/xunit.core/2.9.3, Apache-2.0, approved, #16330
 nuget/nuget/-/xunit.extensibility.core/2.9.3, Apache-2.0 AND MIT, approved, #16334
 nuget/nuget/-/xunit.extensibility.execution/2.9.3, Apache-2.0 AND MIT, approved, #16333
-nuget/nuget/-/xunit.runner.visualstudio/2.8.2, Apache-2.0 AND MIT, approved, #15181
+nuget/nuget/-/xunit.runner.visualstudio/3.0.1, Apache-2.0 AND MIT, approved, #19188
 nuget/nuget/-/xunit/2.9.3, Apache-2.0 AND MIT, approved, #16327

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To see the latest open API specs you can have a look at the [API Hub](https://ec
 
 ## How to build and run
 
-Install the [.NET 8.0 SDK](https://www.microsoft.com/net/download).
+Install the [.NET 9.0 SDK](https://www.microsoft.com/net/download).
 
 Run the following command from the CLI:
 

--- a/docker/Dockerfile-policy-hub-migrations
+++ b/docker/Dockerfile-policy-hub-migrations
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS publish
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS publish
 ARG TARGETARCH
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
@@ -25,7 +25,7 @@ COPY /src/database /src/database
 WORKDIR /src/database/PolicyHub.Migrations
 RUN dotnet publish "PolicyHub.Migrations.csproj" -c Release -o /migrations/publish
 
-FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine
+FROM mcr.microsoft.com/dotnet/runtime:9.0-alpine
 ENV COMPlus_EnableDiagnostics=0
 WORKDIR /migrations
 COPY --from=publish /migrations/publish .

--- a/docker/Dockerfile-policy-hub-service
+++ b/docker/Dockerfile-policy-hub-service
@@ -17,7 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS publish
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS publish
 ARG TARGETARCH
 WORKDIR /
 COPY LICENSE NOTICE.md DEPENDENCIES /
@@ -25,7 +25,7 @@ COPY src/ src/
 WORKDIR /src/hub/PolicyHub.Service
 RUN dotnet publish "PolicyHub.Service.csproj" -c Release -o /app/publish
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
 ENV \
     COMPlus_EnableDiagnostics=0 \
     ASPNETCORE_URLS=http://+:8080

--- a/docker/notice-policy-hub-migrations.md
+++ b/docker/notice-policy-hub-migrations.md
@@ -13,7 +13,7 @@ __Policy Hub Migrations__
 
 __Used base images__
 
-- Dockerfile: [mcr.microsoft.com/dotnet/runtime:8.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime/8.0/alpine3.19/amd64/Dockerfile)
+- Dockerfile: [mcr.microsoft.com/dotnet/runtime:9.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/runtime/9.0/alpine3.20/amd64/Dockerfile)
 - GitHub project: [https://github.com/dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker)
 - DockerHub: [https://hub.docker.com/_/microsoft-dotnet-runtime](https://hub.docker.com/_/microsoft-dotnet-runtime)
 

--- a/docker/notice-policy-hub-service.md
+++ b/docker/notice-policy-hub-service.md
@@ -13,7 +13,7 @@ __Policy Hub Service__
 
 __Used base images__
 
-- Dockerfile: [mcr.microsoft.com/dotnet/aspnet:8.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/8.0/alpine3.19/amd64/Dockerfile)
+- Dockerfile: [mcr.microsoft.com/dotnet/aspnet:9.0-alpine](https://github.com/dotnet/dotnet-docker/blob/main/src/aspnet/9.0/alpine3.20/amd64/Dockerfile)
 - GitHub project: [https://github.com/dotnet/dotnet-docker](https://github.com/dotnet/dotnet-docker)
 - DockerHub: [https://hub.docker.com/_/microsoft-dotnet-aspnet](https://hub.docker.com/_/microsoft-dotnet-aspnet)
 

--- a/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
+++ b/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.DbAccess</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.DbAccess</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.12" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.17.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
   </ItemGroup>
 
 </Project>

--- a/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
+++ b/src/database/PolicyHub.Entities/PolicyHub.Entities.csproj
@@ -21,17 +21,17 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Entities</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Entities</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
+    <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
   </ItemGroup>
   <ItemGroup>
     <SonarQubeSetting Include="sonar.coverage.exclusions">

--- a/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
+++ b/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Migrations</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Migrations</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -33,20 +33,21 @@
     <SonarQubeExclude>true</SonarQubeExclude>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.12">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.17.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.17.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/database/PolicyHub.Migrations/Program.cs
+++ b/src/database/PolicyHub.Migrations/Program.cs
@@ -18,10 +18,12 @@
  ********************************************************************************/
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Org.Eclipse.TractusX.PolicyHub.Entities;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Logging;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding.DependencyInjection;
 using Serilog;
@@ -38,7 +40,8 @@ try
                 .AddDbContext<PolicyHubContext>(o =>
                     o.UseNpgsql(hostContext.Configuration.GetConnectionString("PolicyHubDb"),
                         x => x.MigrationsAssembly(Assembly.GetExecutingAssembly().GetName().Name)
-                            .MigrationsHistoryTable("__efmigrations_history_hub", "public")))
+                            .MigrationsHistoryTable("__efmigrations_history_hub", "public"))
+                        .ReplaceService<IHistoryRepository, CustomNpgsqlHistoryRepository>())
                 .AddDatabaseInitializer<PolicyHubContext>(hostContext.Configuration.GetSection("Seeding"));
         })
         .AddLogging()

--- a/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
+++ b/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
@@ -22,7 +22,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Service</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Service</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -40,9 +40,9 @@
 
   <ItemGroup>
     <PackageReference Include="Flurl.Signed" Version="4.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.12" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.17.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.3.0" />
     <PackageReference Include="System.Json" Version="4.8.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
+++ b/tests/database/PolicyHub.DbAccess.Tests/PolicyHub.DbAccess.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.DbAccess.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.DbAccess.Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -36,7 +36,7 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
@@ -44,7 +44,7 @@
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
+++ b/tests/database/PolicyHub.Entities.Tests/PolicyHub.Entities.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Entities.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Entities.Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -40,7 +40,7 @@
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Xunit.Extensions.AssemblyFixture" Version="2.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
+++ b/tests/hub/PolicyHub.Service.Tests/PolicyHub.Service.Tests.csproj
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <AssemblyName>Org.Eclipse.TractusX.PolicyHub.Service.Tests</AssemblyName>
     <RootNamespace>Org.Eclipse.TractusX.PolicyHub.Service.Tests</RootNamespace>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -37,12 +37,12 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.18.1" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description

Upgrade .NET to v9

## Why

To have the latest dotnet version in the projects

## Issue

n/a

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)