### PR TITLE
fix: Use correct JSON-LD context prefix

### DIFF
--- a/docs/api/hub-service.yaml
+++ b/docs/api/hub-service.yaml
@@ -722,7 +722,6 @@ components:
         - NotNullableValueTypeConstraint
         - DefaultConstructorConstraint
         - SpecialConstraintMask
-        - AllowByRefLike
       type: string
     ICustomAttributeProvider:
       type: object
@@ -1309,6 +1308,9 @@ components:
           type: integer
           format: int32
           readOnly: true
+        isInterface:
+          type: boolean
+          readOnly: true
         memberType:
           $ref: '#/components/schemas/MemberTypes'
         namespace:
@@ -1327,9 +1329,6 @@ components:
           $ref: '#/components/schemas/Assembly'
         module:
           $ref: '#/components/schemas/Module'
-        isInterface:
-          type: boolean
-          readOnly: true
         isNested:
           type: boolean
           readOnly: true
@@ -1559,6 +1558,9 @@ components:
           type: integer
           format: int32
           readOnly: true
+        isInterface:
+          type: boolean
+          readOnly: true
         memberType:
           $ref: '#/components/schemas/MemberTypes'
         namespace:
@@ -1577,9 +1579,6 @@ components:
           $ref: '#/components/schemas/Assembly'
         module:
           $ref: '#/components/schemas/Module'
-        isInterface:
-          type: boolean
-          readOnly: true
         isNested:
           type: boolean
           readOnly: true

--- a/docs/api/hub-service.yaml
+++ b/docs/api/hub-service.yaml
@@ -722,6 +722,7 @@ components:
         - NotNullableValueTypeConstraint
         - DefaultConstructorConstraint
         - SpecialConstraintMask
+        - AllowByRefLike
       type: string
     ICustomAttributeProvider:
       type: object
@@ -1308,9 +1309,6 @@ components:
           type: integer
           format: int32
           readOnly: true
-        isInterface:
-          type: boolean
-          readOnly: true
         memberType:
           $ref: '#/components/schemas/MemberTypes'
         namespace:
@@ -1329,6 +1327,9 @@ components:
           $ref: '#/components/schemas/Assembly'
         module:
           $ref: '#/components/schemas/Module'
+        isInterface:
+          type: boolean
+          readOnly: true
         isNested:
           type: boolean
           readOnly: true
@@ -1558,9 +1559,6 @@ components:
           type: integer
           format: int32
           readOnly: true
-        isInterface:
-          type: boolean
-          readOnly: true
         memberType:
           $ref: '#/components/schemas/MemberTypes'
         namespace:
@@ -1579,6 +1577,9 @@ components:
           $ref: '#/components/schemas/Assembly'
         module:
           $ref: '#/components/schemas/Module'
+        isInterface:
+          type: boolean
+          readOnly: true
         isNested:
           type: boolean
           readOnly: true

--- a/docs/api/postman/policy-hub.postman_collection.json
+++ b/docs/api/postman/policy-hub.postman_collection.json
@@ -446,7 +446,7 @@
 						}
 					],
 					"cookie": [],
-					"body": "{\n    \"content\": {\n        \"@context\": [\n            \"https://www.w3.org/ns/odrl.jsonld\",\n            {\n                \"cx\": \"https://w3id.org/catenax/v0.0.1/ns/\"\n            }\n        ],\n        \"@type\": \"Offer\",\n        \"@id\": \"....\",\n        \"permission\": {\n            \"action\": \"use\",\n            \"constraint\": {\n                \"leftOperand\": \"Dismantler.activityType\",\n                \"operator\": \"in\",\n                \"rightOperand\": [\n                    \"Audi\",\n                    \"BMW\",\n                    \"VW\"\n                ]\n            }\n        }\n    }\n}"
+					"body": "{\n    \"content\": {\n        \"@context\": [\n            \"https://www.w3.org/ns/odrl.jsonld\",\n            {\n                \"cx-policy\": \"https://w3id.org/catenax/v0.0.1/ns/\"\n            }\n        ],\n        \"@type\": \"Offer\",\n        \"@id\": \"....\",\n        \"permission\": {\n            \"action\": \"use\",\n            \"constraint\": {\n                \"leftOperand\": \"Dismantler.activityType\",\n                \"operator\": \"in\",\n                \"rightOperand\": [\n                    \"Audi\",\n                    \"BMW\",\n                    \"VW\"\n                ]\n            }\n        }\n    }\n}"
 				}
 			]
 		},

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -256,5 +256,5 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         return new PolicyResponse(content, additionalAttributes);
     }
 
-    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/v0.0.1/ns/" } };
+    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext("https://w3id.org/catenax/v0.0.1/ns/") };
 }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -256,5 +256,5 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         return new PolicyResponse(content, additionalAttributes);
     }
 
-    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new { cx = "https://w3id.org/catenax/v0.0.1/ns/" } };
+    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/v0.0.1/ns/" } };
 }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -256,5 +256,5 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         return new PolicyResponse(content, additionalAttributes);
     }
 
-    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext("https://w3id.org/catenax/v0.0.1/ns/") };
+    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/v0.0.1/ns/" } };
 }

--- a/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
+++ b/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
@@ -39,9 +39,11 @@ public record PolicyFileContent
     [property: JsonPropertyName("permission")] Permission Permission
 );
 
-public record PolicyContext(
-    [property: JsonPropertyName("cx-policy")] string CxPolicy
-);
+public record PolicyContext
+{
+    [JsonPropertyName("cx-policy")]
+    public required string CxPolicy { get; set; }
+}
 
 public record Permission
 (

--- a/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
+++ b/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
@@ -39,6 +39,12 @@ public record PolicyFileContent
     [property: JsonPropertyName("permission")] Permission Permission
 );
 
+public record PolicyContext
+{
+    [JsonPropertyName("cx-policy")]
+    public required string CxPolicy { get; set; }
+}
+
 public record Permission
 (
     [property: JsonPropertyName("action")] string Action,

--- a/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
+++ b/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
@@ -39,11 +39,9 @@ public record PolicyFileContent
     [property: JsonPropertyName("permission")] Permission Permission
 );
 
-public record PolicyContext
-{
-    [JsonPropertyName("cx-policy")]
-    public required string CxPolicy { get; set; }
-}
+public record PolicyContext(
+    [property: JsonPropertyName("cx-policy")] string CxPolicy
+);
 
 public record Permission
 (

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -160,7 +160,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}}}}");
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Membership\",\"operator\":\"eq\",\"rightOperand\":\"active\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Membership\",\"operator\":\"eq\",\"rightOperand\":\"active\"}}}}");
     }
 
     #endregion
@@ -227,7 +227,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:UsagePurpose\",\"operator\":\"in\",\"rightOperand\":[\"cx.circular.dpp:1\",\"cx.circular.smc:1\",\"cx.circular.marketplace:1\",\"cx.circular.materialaccounting:1\",\"cx.bpdm.gate.upload:1\",\"cx.bpdm.gate.download:1\",\"cx.bpdm.pool:1\",\"cx.bpdm.vas.dataquality.upload:1\",\"cx.bpdm.vas.dataquality.download:1\",\"cx.bpdm.vas.bdv.upload:1\",\"cx.bpdm.vas.bdv.download:1\",\"cx.bpdm.vas.fpd.upload:1\",\"cx.bpdm.vas.fpd.download:1\",\"cx.bpdm.vas.swd.upload:1\",\"cx.bpdm.vas.swd.download:1\",\"cx.bpdm.vas.nps.upload:1\",\"cx.bpdm.vas.nps.download:1\",\"cx.bpdm.vas.countryrisk:1\",\"cx.behaviortwin.base:1\",\"cx.core.digitalTwinRegistry:1\",\"cx.core.tractionbattery:1\",\"cx.core.industrycore:1\",\"cx.core.qualityNotifications:1\",\"cx.pcf.base:1\",\"cx.quality.base:1\",\"cx.dcm.base:1\",\"cx.puris.base:1\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:UsagePurpose\",\"operator\":\"in\",\"rightOperand\":[\"cx.circular.dpp:1\",\"cx.circular.smc:1\",\"cx.circular.marketplace:1\",\"cx.circular.materialaccounting:1\",\"cx.bpdm.gate.upload:1\",\"cx.bpdm.gate.download:1\",\"cx.bpdm.pool:1\",\"cx.bpdm.vas.dataquality.upload:1\",\"cx.bpdm.vas.dataquality.download:1\",\"cx.bpdm.vas.bdv.upload:1\",\"cx.bpdm.vas.bdv.download:1\",\"cx.bpdm.vas.fpd.upload:1\",\"cx.bpdm.vas.fpd.download:1\",\"cx.bpdm.vas.swd.upload:1\",\"cx.bpdm.vas.swd.download:1\",\"cx.bpdm.vas.nps.upload:1\",\"cx.bpdm.vas.nps.download:1\",\"cx.bpdm.vas.countryrisk:1\",\"cx.behaviortwin.base:1\",\"cx.core.digitalTwinRegistry:1\",\"cx.core.tractionbattery:1\",\"cx.core.industrycore:1\",\"cx.core.qualityNotifications:1\",\"cx.pcf.base:1\",\"cx.quality.base:1\",\"cx.dcm.base:1\",\"cx.puris.base:1\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Offer\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     #endregion


### PR DESCRIPTION
Description

In the returned policies, the policy hub adds the https://w3id.org/catenax/v0.0.1/ns/ context with the cx prefix, but then uses the cx-policy prefix instead.

Why

The cx-policy prefix isn’t bound to any context within the JSON-LD document and therefore will fail to expand during serialization.

Issue

N/A

## Issue

Link to Github issue.

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [ ] I have created and linked IP issues or requested their creation by a committer
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)