### PR TITLE
fix(errorHandling): adjust general error handler

### DIFF
--- a/src/database/PolicyHub.DbAccess/IHubRepositories.cs
+++ b/src/database/PolicyHub.DbAccess/IHubRepositories.cs
@@ -21,5 +21,5 @@ namespace Org.Eclipse.TractusX.PolicyHub.DbAccess;
 
 public interface IHubRepositories
 {
-    public T GetInstance<T>();
+    T GetInstance<T>();
 }

--- a/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
+++ b/src/database/PolicyHub.DbAccess/PolicyHub.DbAccess.csproj
@@ -33,8 +33,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="3.5.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="3.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
+++ b/src/database/PolicyHub.Migrations/PolicyHub.Migrations.csproj
@@ -45,9 +45,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="3.5.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="3.5.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/hub/PolicyHub.Service/ErrorHandling/ErrorMessageContainer.cs
+++ b/src/hub/PolicyHub.Service/ErrorHandling/ErrorMessageContainer.cs
@@ -1,0 +1,64 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using System.Collections.Immutable;
+
+namespace Org.Eclipse.TractusX.PolicyHub.Service.ErrorHandling;
+
+public class ErrorMessageContainer : IErrorMessageContainer
+{
+    private static readonly IReadOnlyDictionary<int, string> Messages = ImmutableDictionary.CreateRange<int, string>([
+        new((int)PolicyErrors.POLICY_NOT_EXIST, "Policy for type {type} and technicalKey {credential} does not exists"),
+        new((int)PolicyErrors.NO_RIGHT_OPERAND_CONFIGURED, "There must be one configured rightOperand value"),
+        new((int)PolicyErrors.INVALID_VALUES, "Invalid values [{value}] set for key {leftOperand}. Possible values [{possibleValues}]"),
+        new((int)PolicyErrors.NO_VALUE_FOR_REGEX, "you must provide a value for the regex"),
+        new((int)PolicyErrors.MULTIPLE_REGEX_DEFINED, "There should only be one regex pattern defined"),
+        new((int)PolicyErrors.VALUE_DOES_NOT_MATCH_REGEX, "The provided value {value} does not match the regex pattern {values}"),
+        new((int)PolicyErrors.OR_WITH_USAGE, "The support of OR constraintOperand for Usage constraints are not supported for now"),
+        new((int)PolicyErrors.SINGLE_VALUE_BPNL_CONSTRAINT, "Only a single value BPNL is allowed with an AND constraint"),
+        new((int)PolicyErrors.BPNL_WRONG_OPERATOR, "The operator for BPNLs should always be Equals"),
+        new((int)PolicyErrors.USAGE_MULTIPLE_BPNL, "For usage policies only a single BPNL is allowed"),
+        new((int)PolicyErrors.KEY_DEFINED_MULTIPLE_TIMES, "Keys {keys} have been defined multiple times"),
+        new((int)PolicyErrors.POLICY_NOT_EXISTS_FOR_TECHNICAL_KEYS, "Policy for type {policyType} and requested technicalKeys does not exists. TechnicalKeys {technicalKeys} are allowed"),
+        new((int)PolicyErrors.INVALID_VALUES_SET, "Invalid values set for {values}"),
+        new((int)PolicyErrors.RIGHT_OPERAND_NOT_CONFIGURED, "There must be one configured rightOperand value")
+    ]);
+
+    public Type Type { get => typeof(PolicyErrors); }
+    public IReadOnlyDictionary<int, string> MessageContainer { get => Messages; }
+}
+
+public enum PolicyErrors
+{
+    POLICY_NOT_EXIST,
+    NO_RIGHT_OPERAND_CONFIGURED,
+    INVALID_VALUES,
+    NO_VALUE_FOR_REGEX,
+    MULTIPLE_REGEX_DEFINED,
+    VALUE_DOES_NOT_MATCH_REGEX,
+    OR_WITH_USAGE,
+    SINGLE_VALUE_BPNL_CONSTRAINT,
+    BPNL_WRONG_OPERATOR,
+    USAGE_MULTIPLE_BPNL,
+    KEY_DEFINED_MULTIPLE_TIMES,
+    POLICY_NOT_EXISTS_FOR_TECHNICAL_KEYS,
+    INVALID_VALUES_SET,
+    RIGHT_OPERAND_NOT_CONFIGURED
+}

--- a/src/hub/PolicyHub.Service/ErrorHandling/GeneralHttpErrorHandler.cs
+++ b/src/hub/PolicyHub.Service/ErrorHandling/GeneralHttpErrorHandler.cs
@@ -1,0 +1,144 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Service;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
+using Serilog.Context;
+using System.Collections.Immutable;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Org.Eclipse.TractusX.PolicyHub.Service.ErrorHandling;
+
+public class GeneralHttpErrorHandler(
+    RequestDelegate next,
+    ILogger<GeneralHttpErrorHandler> logger,
+    IErrorMessageService errorMessageService)
+{
+    private static readonly JsonSerializerOptions Options = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private readonly ILogger _logger = logger;
+
+    private static readonly IReadOnlyDictionary<HttpStatusCode, MetaData> Metadata = ImmutableDictionary.CreateRange(new[]
+    {
+        KeyValuePair.Create(HttpStatusCode.BadRequest, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.1", "One or more validation errors occurred.")),
+        KeyValuePair.Create(HttpStatusCode.Conflict, new MetaData("https://tools.ietf.org/html/rfc7231#section-6.5.8", "The resource is in conflict with the current request.")),
+        KeyValuePair.Create(HttpStatusCode.NotFound, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.4", "Cannot find representation of target resource.")),
+        KeyValuePair.Create(HttpStatusCode.Forbidden, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.3", "Access to requested resource is not permitted.")),
+        KeyValuePair.Create(HttpStatusCode.UnsupportedMediaType, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.5.13", "The server cannot process this type of content")),
+        KeyValuePair.Create(HttpStatusCode.BadGateway, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.3", "Error accessing external resource.")),
+        KeyValuePair.Create(HttpStatusCode.ServiceUnavailable, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.4", "Service is currently unavailable.")),
+        KeyValuePair.Create(HttpStatusCode.InternalServerError, new MetaData("https://datatracker.ietf.org/doc/html/rfc7231#section-6.6.1", "The server encountered an unexpected condition.")),
+    });
+
+    private static KeyValuePair<Type, (HttpStatusCode HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> CreateErrorEntry<T>(
+            HttpStatusCode httpStatusCode,
+            Func<T, (string?, IEnumerable<string>)>? messageFunc = null,
+            LogLevel logLevel = LogLevel.Information
+        ) where T : class =>
+            KeyValuePair.Create<Type, (HttpStatusCode, Func<Exception, (string?, IEnumerable<string>)>?, LogLevel)>(
+                typeof(T),
+                (httpStatusCode,
+                messageFunc == null
+                    ? null
+                    : e => messageFunc.Invoke(e as T ?? throw new UnexpectedConditionException($"Exception type {e.GetType()} should always be of type {typeof(T)} here")),
+                logLevel));
+
+    private static readonly IReadOnlyDictionary<Type, (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel)> ErrorTypes = ImmutableDictionary.CreateRange(new[]
+    {
+        CreateErrorEntry<ArgumentException>(HttpStatusCode.BadRequest, argumentException => (argumentException.ParamName, Enumerable.Repeat(argumentException.Message, 1))),
+        CreateErrorEntry<ControllerArgumentException>(HttpStatusCode.BadRequest, caException => (caException.ParamName, Enumerable.Repeat(caException.Message, 1))),
+        CreateErrorEntry<NotFoundException>(HttpStatusCode.NotFound),
+        CreateErrorEntry<ConflictException>(HttpStatusCode.Conflict),
+        CreateErrorEntry<ForbiddenException>(HttpStatusCode.Forbidden),
+        CreateErrorEntry<ServiceException>(HttpStatusCode.BadGateway, serviceException => (serviceException.Source, new[] { serviceException.StatusCode == null ? "remote service call failed" : $"remote service returned status code: {(int) serviceException.StatusCode} {serviceException.StatusCode}", serviceException.Message })),
+        CreateErrorEntry<UnsupportedMediaTypeException>(HttpStatusCode.UnsupportedMediaType),
+        CreateErrorEntry<ConfigurationException>(HttpStatusCode.InternalServerError, configurationException => (configurationException.Source, new[] { $"Invalid service configuration: {configurationException.Message}" }))
+    });
+
+    public async Task Invoke(HttpContext context)
+    {
+        try
+        {
+            await next(context).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+        catch (Exception error)
+        {
+            var errorId = Guid.NewGuid().ToString();
+            var details = GetErrorDetails(error);
+            var message = GetErrorMessage(error);
+            LogErrorInformation(errorId, error);
+            var (statusCode, messageFunc, logLevel) = GetErrorInformation(error);
+            _logger.Log(logLevel, error, "GeneralErrorHandler caught {Error} with errorId: {ErrorId} resulting in response status code {StatusCode}, message '{Message}'", error.GetType().Name, errorId, (int)statusCode, message);
+            context.Response.ContentType = "application/json";
+            context.Response.StatusCode = (int)statusCode;
+            await context.Response.WriteAsync(JsonSerializer.Serialize(CreateErrorResponse(statusCode, error, errorId, message, details, messageFunc), Options)).ConfigureAwait(ConfigureAwaitOptions.None);
+        }
+    }
+
+    private static (HttpStatusCode StatusCode, Func<Exception, (string?, IEnumerable<string>)>? MessageFunc, LogLevel LogLevel) GetErrorInformation(Exception error) =>
+        ErrorTypes.TryGetValue(error.GetType(), out var mapping)
+            ? mapping
+            : (HttpStatusCode.InternalServerError, null, LogLevel.Error);
+
+    private ErrorResponse CreateErrorResponse(HttpStatusCode statusCode, Exception error, string errorId, string message, IEnumerable<ErrorDetails>? details, Func<Exception, (string?, IEnumerable<string>)>? getSourceAndMessages)
+    {
+        var meta = Metadata.GetValueOrDefault(statusCode, Metadata[HttpStatusCode.InternalServerError]);
+        var (source, messages) = getSourceAndMessages?.Invoke(error) ?? (error.Source, Enumerable.Repeat(message, 1));
+
+        var messageMap = new Dictionary<string, IEnumerable<string>> { { source ?? "unknown", messages } };
+        while (error.InnerException != null)
+        {
+            error = error.InnerException;
+            source = error.Source ?? "inner";
+
+            messageMap[source] = messageMap.TryGetValue(source, out messages)
+                ? messages.Append(GetErrorMessage(error))
+                : Enumerable.Repeat(GetErrorMessage(error), 1);
+        }
+
+        return new ErrorResponse(
+            meta.Url,
+            meta.Description,
+            (int)statusCode,
+            messageMap,
+            errorId,
+            details
+        );
+    }
+
+    private string GetErrorMessage(Exception exception) =>
+        exception is DetailException { HasDetails: true } detail
+            ? detail.GetErrorMessage(errorMessageService)
+            : exception.Message;
+
+    private IEnumerable<ErrorDetails> GetErrorDetails(Exception exception) =>
+        exception is DetailException { HasDetails: true } detail
+            ? detail.GetErrorDetails(errorMessageService)
+            : Enumerable.Empty<ErrorDetails>();
+
+    private static void LogErrorInformation(string errorId, Exception exception)
+    {
+        LogContext.PushProperty("ErrorId", errorId);
+        LogContext.PushProperty("StackTrace", exception.StackTrace);
+    }
+
+    private sealed record MetaData(string Url, string Description);
+}

--- a/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
+++ b/src/hub/PolicyHub.Service/PolicyHub.Service.csproj
@@ -42,7 +42,8 @@
     <PackageReference Include="Flurl.Signed" Version="4.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.3.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web" Version="3.5.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="3.5.0" />
     <PackageReference Include="System.Json" Version="4.8.0" />
     <PackageReference Include="System.Linq" Version="4.3.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/BusinessLogic/PolicyHubBusinessLogicTests.cs
@@ -22,6 +22,7 @@ using Org.Eclipse.TractusX.PolicyHub.DbAccess.Models;
 using Org.Eclipse.TractusX.PolicyHub.DbAccess.Repositories;
 using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.BusinessLogic;
+using Org.Eclipse.TractusX.PolicyHub.Service.ErrorHandling;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
@@ -111,7 +112,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
 
         // Assert
-        ex.Message.Should().Be($"Policy for type {policyTypeId} and technicalKey membership does not exists");
+        ex.Message.Should().Be(PolicyErrors.POLICY_NOT_EXIST.ToString());
     }
 
     [Fact]
@@ -127,7 +128,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
 
         // Assert
-        ex.Message.Should().Be("There must be one configured rightOperand value");
+        ex.Message.Should().Be(PolicyErrors.NO_RIGHT_OPERAND_CONFIGURED.ToString());
     }
 
     [Fact]
@@ -158,7 +159,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
 
         // Assert
-        ex.Message.Should().Be("There should only be one regex pattern defined");
+        ex.Message.Should().Be(PolicyErrors.MULTIPLE_REGEX_DEFINED.ToString());
     }
 
     [Fact]
@@ -202,7 +203,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("Invalid values [test] set for key multipleAdditionalValues. Possible values [value1,value2,value3]");
+        ex.Message.Should().Be(PolicyErrors.INVALID_VALUES.ToString());
     }
 
     #endregion
@@ -232,7 +233,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<NotFoundException>(Act);
 
         // Assert
-        ex.Message.Should().Be($"Policy for type {data.PolicyType} and technicalKeys abc does not exists");
+        ex.Message.Should().Be(PolicyErrors.POLICY_NOT_EXISTS_FOR_TECHNICAL_KEYS.ToString());
     }
 
     [Fact]
@@ -255,7 +256,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be($"Policy for type {data.PolicyType} and requested technicalKeys does not exists. TechnicalKeys test are allowed");
+        ex.Message.Should().Be(PolicyErrors.POLICY_NOT_EXISTS_FOR_TECHNICAL_KEYS.ToString());
     }
 
     [Fact]
@@ -281,7 +282,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("Invalid values set for Key: test, requested value[abc] Possible Values[test]");
+        ex.Message.Should().Be(PolicyErrors.INVALID_VALUES_SET.ToString());
     }
 
     [Fact]
@@ -303,7 +304,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<UnexpectedConditionException>(Act);
 
         // Assert
-        ex.Message.Should().Be("There must be one configured rightOperand value");
+        ex.Message.Should().Be(PolicyErrors.RIGHT_OPERAND_NOT_CONFIGURED.ToString());
     }
 
     [Fact]
@@ -325,8 +326,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.ParamName.Should().Be("value");
-        ex.Message.Should().Be("you must provide a value for the regex (Parameter 'value')");
+        ex.Message.Should().Be(PolicyErrors.NO_VALUE_FOR_REGEX.ToString());
     }
 
     [Fact]
@@ -348,8 +348,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.ParamName.Should().Be("value");
-        ex.Message.Should().Be(@"The provided value testRegValue does not match the regex pattern ^BPNL[\w|\d]{12}$ (Parameter 'value')");
+        ex.Message.Should().Be(PolicyErrors.VALUE_DOES_NOT_MATCH_REGEX.ToString());
     }
 
     [Fact]
@@ -370,7 +369,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("The support of OR constraintOperand for Usage constraints are not supported for now");
+        ex.Message.Should().Be(PolicyErrors.OR_WITH_USAGE.ToString());
     }
 
     [Fact]
@@ -391,7 +390,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("Only a single value BPNL is allowed with an AND constraint");
+        ex.Message.Should().Be(PolicyErrors.SINGLE_VALUE_BPNL_CONSTRAINT.ToString());
     }
 
     [Fact]
@@ -412,7 +411,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("The operator for BPNLs should always be Equals");
+        ex.Message.Should().Be(PolicyErrors.BPNL_WRONG_OPERATOR.ToString());
     }
 
     [Fact]
@@ -433,7 +432,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("For usage policies only a single BPNL is allowed");
+        ex.Message.Should().Be(PolicyErrors.USAGE_MULTIPLE_BPNL.ToString());
     }
 
     [Fact]
@@ -459,7 +458,7 @@ public class PolicyHubBusinessLogicTests
         var ex = await Assert.ThrowsAsync<ControllerArgumentException>(Act);
 
         // Assert
-        ex.Message.Should().Be("Keys test have been defined multiple times");
+        ex.Message.Should().Be(PolicyErrors.KEY_DEFINED_MULTIPLE_TIMES.ToString());
     }
 
     [Fact]

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -131,8 +131,8 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
-        error!.Errors.Should().ContainSingle().And.Satisfy(
-            x => x.Value.Single() == @"The provided value notmatching does not match the regex pattern ^BPNL[\w|\d]{12}$ (Parameter 'value')");
+        error!.Details.Should().ContainSingle().And.Satisfy(
+            x => x.Message == "The provided value {value} does not match the regex pattern {values}" && x.Parameters.Count() == 2);
     }
 
     [Fact]
@@ -145,8 +145,8 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.Should().NotBeNull();
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var error = await response.Content.ReadFromJsonAsync<ErrorResponse>(JsonOptions);
-        error!.Errors.Should().ContainSingle().And.Satisfy(
-            x => x.Value.Single() == "you must provide a value for the regex (Parameter 'value')");
+        error!.Details.Should().ContainSingle().And.Satisfy(
+            x => x.Message == "you must provide a value for the regex");
     }
 
     [Fact]


### PR DESCRIPTION
## Description

fixing the current error handling

## Why

after the net 9 upgrade the general error handling was broken and always returned a 500

## Issue

N/A

## Checklist

- [x] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [x] I have performed [IP checks](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool) for added or updated 3rd party libraries
- [x] I have created and linked IP issues or requested their creation by a committer
- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)