### PR TITLE
fix: access modifiers on interface

### DIFF
--- a/src/database/PolicyHub.DbAccess/IHubRepositories.cs
+++ b/src/database/PolicyHub.DbAccess/IHubRepositories.cs
@@ -21,5 +21,5 @@ namespace Org.Eclipse.TractusX.PolicyHub.DbAccess;
 
 public interface IHubRepositories
 {
-    public T GetInstance<T>();
+    T GetInstance<T>();
 }


### PR DESCRIPTION
## Description

remove public access-modifier on interface-method

## Why

interface methods must not declare access-modifiers. The issue blocks https://github.com/eclipse-tractusx/policy-hub/pull/224 as it causes the format-scan to fail

## Issue

N/A

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have checked that new and existing tests pass locally with my changes