### PR TITLE
fix(json-ld): adjust namespace and usage of cx-profile

### DIFF
--- a/docs/api/hub-service.yaml
+++ b/docs/api/hub-service.yaml
@@ -1163,6 +1163,8 @@ components:
           type: string
         '@id':
           type: string
+        profile:
+          type: string
         permission:
           $ref: '#/components/schemas/Permission'
       additionalProperties: false

--- a/docs/api/postman/example-requests.md
+++ b/docs/api/postman/example-requests.md
@@ -113,15 +113,16 @@ A possible response can look like this:
         "@context": [
             "https://www.w3.org/ns/odrl.jsonld",
             {
-                "cx": "https://w3id.org/catenax/v0.0.1/ns/"
+                "cx-policy": "https://w3id.org/catenax/policy/"
             }
         ],
         "@type": "Set",
         "@id": "....",
+        "profile": "cx-policy:profile2405",
         "permission": {
             "action": "use",
             "constraint": {
-                "leftOperand": "FrameworkAgreement.traceability",
+                "leftOperand": "cx-policy:FrameworkAgreement.traceability",
                 "operator": "eq",
                 "rightOperand": "@FrameworkAgreement.traceability-Version"
             }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -259,7 +259,11 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
         return new PolicyResponse(content, additionalAttributes);
     }
 
-    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/policy/" } };
+    private static IEnumerable<object> GetContext() =>
+        [
+            "https://www.w3.org/ns/odrl.jsonld",
+            new PolicyContext { CxPolicy = "https://w3id.org/catenax/policy/" }
+        ];
 
     private static string GetProfile() => "cx-policy:profile2405";
 }

--- a/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
+++ b/src/hub/PolicyHub.Service/BusinessLogic/PolicyHubBusinessLogic.cs
@@ -115,6 +115,7 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             GetContext(),
             "Set",
             "....",
+            GetProfile(),
             new Permission(
                 type.TypeToJsonString(),
                 new Constraint(
@@ -252,10 +253,13 @@ public class PolicyHubBusinessLogic(IHubRepositories hubRepositories)
             GetContext(),
             "Set",
             "....",
+            GetProfile(),
             permission);
 
         return new PolicyResponse(content, additionalAttributes);
     }
 
-    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/v0.0.1/ns/" } };
+    private static IEnumerable<object> GetContext() => new object[] { "https://www.w3.org/ns/odrl.jsonld", new PolicyContext { CxPolicy = "https://w3id.org/catenax/policy/" } };
+
+    private static string GetProfile() => "cx-policy:profile2405";
 }

--- a/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
+++ b/src/hub/PolicyHub.Service/Models/PolicyFileContent.cs
@@ -36,6 +36,7 @@ public record PolicyFileContent
     [property: JsonPropertyName("@context")] IEnumerable<object> Context,
     [property: JsonPropertyName("@type")] string Type,
     [property: JsonPropertyName("@id")] string Id,
+    [property: JsonPropertyName("profile")] string Profile,
     [property: JsonPropertyName("permission")] Permission Permission
 );
 

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -160,7 +160,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/policy/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"profile\":\"cx-policy:profile2405\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"}}}}");
     }
 
     [Fact]
@@ -174,7 +174,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/policy/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"profile\":\"cx-policy:profile2405\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}}}}");
     }
 
     [Fact]
@@ -199,7 +199,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Membership\",\"operator\":\"eq\",\"rightOperand\":\"active\"}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/policy/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"profile\":\"cx-policy:profile2405\",\"permission\":{\"action\":\"use\",\"constraint\":{\"leftOperand\":\"cx-policy:Membership\",\"operator\":\"eq\",\"rightOperand\":\"active\"}}}}");
     }
 
     #endregion
@@ -227,7 +227,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:UsagePurpose\",\"operator\":\"in\",\"rightOperand\":[\"cx.circular.dpp:1\",\"cx.circular.smc:1\",\"cx.circular.marketplace:1\",\"cx.circular.materialaccounting:1\",\"cx.bpdm.gate.upload:1\",\"cx.bpdm.gate.download:1\",\"cx.bpdm.pool:1\",\"cx.bpdm.vas.dataquality.upload:1\",\"cx.bpdm.vas.dataquality.download:1\",\"cx.bpdm.vas.bdv.upload:1\",\"cx.bpdm.vas.bdv.download:1\",\"cx.bpdm.vas.fpd.upload:1\",\"cx.bpdm.vas.fpd.download:1\",\"cx.bpdm.vas.swd.upload:1\",\"cx.bpdm.vas.swd.download:1\",\"cx.bpdm.vas.nps.upload:1\",\"cx.bpdm.vas.nps.download:1\",\"cx.bpdm.vas.countryrisk:1\",\"cx.behaviortwin.base:1\",\"cx.core.digitalTwinRegistry:1\",\"cx.core.tractionbattery:1\",\"cx.core.industrycore:1\",\"cx.core.qualityNotifications:1\",\"cx.pcf.base:1\",\"cx.quality.base:1\",\"cx.dcm.base:1\",\"cx.puris.base:1\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/policy/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"profile\":\"cx-policy:profile2405\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:UsagePurpose\",\"operator\":\"in\",\"rightOperand\":[\"cx.circular.dpp:1\",\"cx.circular.smc:1\",\"cx.circular.marketplace:1\",\"cx.circular.materialaccounting:1\",\"cx.bpdm.gate.upload:1\",\"cx.bpdm.gate.download:1\",\"cx.bpdm.pool:1\",\"cx.bpdm.vas.dataquality.upload:1\",\"cx.bpdm.vas.dataquality.download:1\",\"cx.bpdm.vas.bdv.upload:1\",\"cx.bpdm.vas.bdv.download:1\",\"cx.bpdm.vas.fpd.upload:1\",\"cx.bpdm.vas.fpd.download:1\",\"cx.bpdm.vas.swd.upload:1\",\"cx.bpdm.vas.swd.download:1\",\"cx.bpdm.vas.nps.upload:1\",\"cx.bpdm.vas.nps.download:1\",\"cx.bpdm.vas.countryrisk:1\",\"cx.behaviortwin.base:1\",\"cx.core.digitalTwinRegistry:1\",\"cx.core.tractionbattery:1\",\"cx.core.industrycore:1\",\"cx.core.qualityNotifications:1\",\"cx.pcf.base:1\",\"cx.quality.base:1\",\"cx.dcm.base:1\",\"cx.puris.base:1\"]},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     [Fact]
@@ -272,7 +272,7 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadAsStringAsync())
             .Should()
-            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/v0.0.1/ns/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
+            .Be("{\"content\":{\"@context\":[\"https://www.w3.org/ns/odrl.jsonld\",{\"cx-policy\":\"https://w3id.org/catenax/policy/\"}],\"@type\":\"Set\",\"@id\":\"....\",\"profile\":\"cx-policy:profile2405\",\"permission\":{\"action\":\"use\",\"constraint\":{\"odrl:and\":[{\"leftOperand\":\"cx-policy:BusinessPartnerNumber\",\"operator\":\"eq\",\"rightOperand\":\"BPNL00000003CRHK\"},{\"leftOperand\":\"cx-policy:FrameworkAgreement\",\"operator\":\"eq\",\"rightOperand\":\"DataExchangeGovernance:1.0\"}]}}}}");
     }
 
     #endregion


### PR DESCRIPTION
## Description

- change the iri of the json-ld context namespace-declaration of cx-profile to 'https://w3id.org/catenax/policy/'
- add the mandatory property 'profile', value 'cx-policy:profile2405'
- add the namespace cx-policy to the values of 'leftOperant'

## Why

json-ld output is not complient with https://catenax-ev.github.io/docs/standards/CX-0018-DataspaceConnectivity

## Issue

https://github.com/eclipse-tractusx/policy-hub/issues/262

## Checklist

Please delete options that are not relevant.

- [X] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [X] I have performed a self-review of my own code
- [X] I have successfully tested my changes locally
- [X] I have added tests that prove my changes work
- [X] I have checked that new and existing tests pass locally with my changes