### PR TITLE
feat: respond 4xx when parameters are unrecognised

### DIFF
--- a/docs/api/hub-service.yaml
+++ b/docs/api/hub-service.yaml
@@ -39,12 +39,12 @@ paths:
           in: query
           description: 'OPTIONAL: Type to filter the response'
           schema:
-            $ref: '#/components/schemas/PolicyTypeId'
+            type: string
         - name: useCase
           in: query
           description: 'OPTIONAL: UseCase to filter the response'
           schema:
-            $ref: '#/components/schemas/UseCaseId'
+            type: string
       responses:
         '200':
           description: OK
@@ -75,25 +75,22 @@ paths:
           in: query
           description: 'OPTIONAL: The use case'
           schema:
-            $ref: '#/components/schemas/UseCaseId'
+            type: string
         - name: type
           in: query
           description: 'Policy type for which the policy is supposed to get created. Possible values: ''Access'' or ''Usage'''
-          required: true
           schema:
-            $ref: '#/components/schemas/PolicyTypeId'
+            type: string
         - name: policyName
           in: query
           description: The technical key of the policy
-          required: true
           schema:
             type: string
         - name: operatorType
           in: query
           description: 'Policy Rule operator. Possible values: ''Equals'' or ''In'''
-          required: true
           schema:
-            $ref: '#/components/schemas/OperatorId'
+            type: string
         - name: value
           in: query
           description: 'OPTIONAL: Value to be used for the rightOperand'

--- a/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
+++ b/src/hub/PolicyHub.Service/Controllers/PolicyHubController.cs
@@ -22,6 +22,7 @@ using Org.Eclipse.TractusX.PolicyHub.DbAccess.Models;
 using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 using Org.Eclipse.TractusX.PolicyHub.Service.BusinessLogic;
 using Org.Eclipse.TractusX.PolicyHub.Service.Extensions;
+using Org.Eclipse.TractusX.PolicyHub.Service.Filters;
 using Org.Eclipse.TractusX.PolicyHub.Service.Models;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling.Web;
@@ -56,12 +57,21 @@ public static class PolicyHubController
             .Produces(StatusCodes.Status200OK, typeof(PolicyTypeResponse), Constants.JsonContentType);
 
         policyHub.MapGet("policy-content",
-                (UseCaseId? useCase,
-                PolicyTypeId type,
+                (string? useCase,
+                String type,
                 string policyName,
-                OperatorId operatorType,
+                String operatorType,
                 string? value,
-                IPolicyHubBusinessLogic logic) => logic.GetPolicyContentWithFiltersAsync(useCase, type, policyName, operatorType, value))
+                IPolicyHubBusinessLogic logic) =>
+                {
+                    UseCaseId? useCaseId = null;
+                    if (useCase != null && useCase.Trim() != string.Empty)
+                    {
+                        useCaseId = Enum.Parse<UseCaseId>(useCase, true);
+                    }
+                    return logic.GetPolicyContentWithFiltersAsync(useCaseId, Enum.Parse<PolicyTypeId>(type), policyName, Enum.Parse<OperatorId>(operatorType), value);
+                })
+            .AddEndpointFilter<PolicyContentQueryParametersFilter>()
             .WithSwaggerDescription("Receive the policy template 'access' or 'usage' for a single policy rule based on the request parameters submitted by the user.",
                 "Example: GET: api/policy-hub/policy-content",
                 "OPTIONAL: The use case",

--- a/src/hub/PolicyHub.Service/Filters/BaseQueryParametersFilter.cs
+++ b/src/hub/PolicyHub.Service/Filters/BaseQueryParametersFilter.cs
@@ -1,0 +1,93 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+
+namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
+
+public abstract class BaseQueryParametersFilter : IEndpointFilter
+{
+    protected readonly Dictionary<string, QueryParameterType> _queryParameters;
+
+    protected BaseQueryParametersFilter(Dictionary<string, QueryParameterType> queryParameters)
+    {
+        _queryParameters = queryParameters;
+    }
+
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var queryParams = context.HttpContext.Request.Query;
+
+        // Check for required parameters
+        EnsureRequiredParameters(queryParams);
+
+        // Validate supported query parameters
+        ValidateSupportedQueryParameters(queryParams);
+
+        // Validate enum parameter values
+        ValidateEnumParameters(queryParams);
+
+        // Continue with the next filter or action
+        return await next(context);
+    }
+
+    private void EnsureRequiredParameters(IQueryCollection queryParams)
+    {
+        var missingRequiredParameters = _queryParameters
+            .Where(q => q.Value.IsRequired && GetArgument(queryParams, q.Key) == null)
+            .Select(q => q.Key)
+            .ToList();
+
+        if (missingRequiredParameters.Count != 0)
+        {
+            throw new NotFoundException($"Missing required parameters: {string.Join(", ", missingRequiredParameters)}.");
+        }
+    }
+
+    private void ValidateSupportedQueryParameters(IQueryCollection queryParams)
+    {
+        var invalidParameters = queryParams
+            .Where(q => !_queryParameters.ContainsKey(q.Key))
+            .Select(q => $"{q.Key}")
+            .ToList();
+
+        if (invalidParameters.Count != 0)
+        {
+            throw new ControllerArgumentException($"Invalid query parameters: {string.Join(", ", invalidParameters)}. Supported parameters are: {string.Join(", ", _queryParameters.Keys)}.");
+        }
+    }
+
+    private void ValidateEnumParameters(IQueryCollection queryParams)
+    {
+        foreach (var param in _queryParameters)
+        {
+            var paramValue = GetArgument(queryParams, param.Key);
+            if (paramValue != null && param.Value.EnumType != null)
+            {
+                ParamEnumValidator.ThrowIfInvalidEnumValue(param.Value.EnumType, paramValue, param.Key);
+            }
+        }
+    }
+
+    protected static string? GetArgument(IQueryCollection queryParams, string argumentName)
+    {
+        return queryParams.TryGetValue(argumentName, out var value) ? value.ToString() : null;
+    }
+}
+

--- a/src/hub/PolicyHub.Service/Filters/ParamEnumHelper.cs
+++ b/src/hub/PolicyHub.Service/Filters/ParamEnumHelper.cs
@@ -17,20 +17,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
-
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
 
-public class PolicyContentQueryParametersFilter : BaseQueryParametersFilter
+public static class ParamEnumHelper
 {
-    public PolicyContentQueryParametersFilter() : base(new Dictionary<string, QueryParameterType>
+    public static TEnum? ParseEnum<TEnum>(string? value) where TEnum : struct, Enum
     {
-        { "useCase", new QueryParameterType { IsRequired = false, EnumType = typeof(UseCaseId) } },
-        { "type", new QueryParameterType { IsRequired = true, EnumType = typeof(PolicyTypeId) } },
-        { "policyName", new QueryParameterType { IsRequired = true } },
-        { "operatorType", new QueryParameterType { IsRequired = true, EnumType = typeof(OperatorId) } },
-        { "value", new QueryParameterType { IsRequired = false } }
-    })
-    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return Enum.Parse<TEnum>(value.Trim(), true);
     }
 }

--- a/src/hub/PolicyHub.Service/Filters/ParamEnumValidator.cs
+++ b/src/hub/PolicyHub.Service/Filters/ParamEnumValidator.cs
@@ -17,20 +17,18 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
 
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
 
-public class PolicyContentQueryParametersFilter : BaseQueryParametersFilter
+public static class ParamEnumValidator
 {
-    public PolicyContentQueryParametersFilter() : base(new Dictionary<string, QueryParameterType>
+    public static void ThrowIfInvalidEnumValue(Type enumType, string value, string paramName)
     {
-        { "useCase", new QueryParameterType { IsRequired = false, EnumType = typeof(UseCaseId) } },
-        { "type", new QueryParameterType { IsRequired = true, EnumType = typeof(PolicyTypeId) } },
-        { "policyName", new QueryParameterType { IsRequired = true } },
-        { "operatorType", new QueryParameterType { IsRequired = true, EnumType = typeof(OperatorId) } },
-        { "value", new QueryParameterType { IsRequired = false } }
-    })
-    {
+        if (!Enum.IsDefined(enumType, value))
+        {
+            var acceptedValues = string.Join(", ", Enum.GetNames(enumType));
+            throw new ControllerArgumentException($"Invalid value '{value}' for parameter '{paramName}'. Accepted values are: {acceptedValues}.");
+        }
     }
 }

--- a/src/hub/PolicyHub.Service/Filters/PolicyContentQueryParametersFilter.cs
+++ b/src/hub/PolicyHub.Service/Filters/PolicyContentQueryParametersFilter.cs
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+
+namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
+
+public class PolicyContentQueryParametersFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext context, EndpointFilterDelegate next)
+    {
+        var queryParams = context.HttpContext.Request.Query;
+        var requiredParameters = new[] { "useCase", "type", "policyName", "operatorType", "value" };
+
+        // Validate query parameters
+        ValidateQueryParameters(queryParams, requiredParameters);
+
+        // Validate enum parameters
+        ValidateEnumParameter<UseCaseId>(queryParams, "useCase");
+        ValidateEnumParameter<PolicyTypeId>(queryParams, "type");
+        ValidateEnumParameter<OperatorId>(queryParams, "operatorType");
+
+        // Continue with the next filter or action
+        return await next(context);
+    }
+
+    private static void ValidateQueryParameters(IQueryCollection queryParams, string[] requiredParameters)
+    {
+        var invalidParameters = queryParams
+            .Where(q => !requiredParameters.Contains(q.Key))
+            .Select(q => q.Key)
+            .ToList();
+
+        if (invalidParameters.Any())
+        {
+            throw new ControllerArgumentException($"Invalid query parameters: [{string.Join(", ", invalidParameters)}]. Accepted query parameters: [{string.Join(", ", requiredParameters)}].");
+        }
+    }
+
+    private static void ValidateEnumParameter<TEnum>(IQueryCollection queryParams, string paramName) where TEnum : struct, Enum
+    {
+        var paramValue = GetArgument(queryParams, paramName);
+        if (paramValue != null && !Enum.TryParse<TEnum>(paramValue, true, out _))
+        {
+            ThrowIfInvalidEnumValue<TEnum>(paramValue, paramName);
+        }
+    }
+
+    private static void ThrowIfInvalidEnumValue<TEnum>(string? value, string paramName) where TEnum : struct, Enum
+    {
+        var acceptedValues = string.Join(", ", Enum.GetNames<TEnum>());
+        throw new ControllerArgumentException($"Invalid parameter value: [{paramName}: '{value}']. Accepted values: [{acceptedValues}].");
+    }
+
+    private static string? GetArgument(IQueryCollection queryParams, string argumentName)
+    {
+        return queryParams.TryGetValue(argumentName, out var value) ? value.ToString() : null;
+    }
+}

--- a/src/hub/PolicyHub.Service/Filters/PolicyTypesQueryParametersFilter.cs
+++ b/src/hub/PolicyHub.Service/Filters/PolicyTypesQueryParametersFilter.cs
@@ -21,15 +21,12 @@ using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
 
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
 
-public class PolicyContentQueryParametersFilter : BaseQueryParametersFilter
+public class PolicyTypesQueryParametersFilter : BaseQueryParametersFilter
 {
-    public PolicyContentQueryParametersFilter() : base(new Dictionary<string, QueryParameterType>
+    public PolicyTypesQueryParametersFilter() : base(new Dictionary<string, QueryParameterType>
     {
         { "useCase", new QueryParameterType { IsRequired = false, EnumType = typeof(UseCaseId) } },
-        { "type", new QueryParameterType { IsRequired = true, EnumType = typeof(PolicyTypeId) } },
-        { "policyName", new QueryParameterType { IsRequired = true } },
-        { "operatorType", new QueryParameterType { IsRequired = true, EnumType = typeof(OperatorId) } },
-        { "value", new QueryParameterType { IsRequired = false } }
+        { "type", new QueryParameterType { IsRequired = false, EnumType = typeof(PolicyTypeId) } }
     })
     {
     }

--- a/src/hub/PolicyHub.Service/Filters/QueryParameterType.cs
+++ b/src/hub/PolicyHub.Service/Filters/QueryParameterType.cs
@@ -17,20 +17,32 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
-
 namespace Org.Eclipse.TractusX.PolicyHub.Service.Filters;
 
-public class PolicyContentQueryParametersFilter : BaseQueryParametersFilter
+public class QueryParameterType
 {
-    public PolicyContentQueryParametersFilter() : base(new Dictionary<string, QueryParameterType>
+    public bool IsRequired { get; set; }
+    public Type? EnumType { get; set; }
+    private object? _enumValue;
+
+    public object? EnumValue
     {
-        { "useCase", new QueryParameterType { IsRequired = false, EnumType = typeof(UseCaseId) } },
-        { "type", new QueryParameterType { IsRequired = true, EnumType = typeof(PolicyTypeId) } },
-        { "policyName", new QueryParameterType { IsRequired = true } },
-        { "operatorType", new QueryParameterType { IsRequired = true, EnumType = typeof(OperatorId) } },
-        { "value", new QueryParameterType { IsRequired = false } }
-    })
+        get => _enumValue;
+        set
+        {
+            if (value is Enum)
+            {
+                _enumValue = value;
+            }
+            else
+            {
+                throw new ArgumentException("Value must be an enum type.");
+            }
+        }
+    }
+
+    public void SetEnumValue<TEnum>(TEnum value) where TEnum : struct, Enum
     {
+        EnumValue = value;
     }
 }

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -276,4 +276,19 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     }
 
     #endregion
+
+    #region Swagger
+
+    [Fact]
+    public async Task CheckSwagger_ReturnsExpected()
+    {
+        // Act
+        var response = await _client.GetAsync($"{BaseUrl}/swagger/v2/swagger.json");
+
+        // Assert
+        response.Should().NotBeNull();
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    #endregion
 }

--- a/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Controllers/PolicyHubControllerTests.cs
@@ -276,19 +276,4 @@ public class PolicyHubControllerTests : IClassFixture<IntegrationTestFactory>
     }
 
     #endregion
-
-    #region Swagger
-
-    [Fact]
-    public async Task CheckSwagger_ReturnsExpected()
-    {
-        // Act
-        var response = await _client.GetAsync($"{BaseUrl}/swagger/v2/swagger.json");
-
-        // Assert
-        response.Should().NotBeNull();
-        response.StatusCode.Should().Be(HttpStatusCode.OK);
-    }
-
-    #endregion
 }

--- a/tests/hub/PolicyHub.Service.Tests/Filters/PolicyContentQueryParametersFilterTests.cs
+++ b/tests/hub/PolicyHub.Service.Tests/Filters/PolicyContentQueryParametersFilterTests.cs
@@ -1,0 +1,115 @@
+/********************************************************************************
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+namespace Org.Eclipse.TractusX.PolicyHub.Service.Tests.Filters;
+
+using FakeItEasy;
+using Microsoft.AspNetCore.Http;
+using Org.Eclipse.TractusX.PolicyHub.Entities.Enums;
+using Org.Eclipse.TractusX.PolicyHub.Service.Filters;
+using Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+public class PolicyContentQueryParametersFilterTests
+{
+    [Fact]
+    public async Task InvokeAsync_ValidParameters_ContinuesToNext()
+    {
+        // Arrange
+        var queryParams = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            { "useCase", UseCaseId.Quality.ToString() },
+            { "type", PolicyTypeId.Access.ToString() },
+            { "policyName", "UsagePurpose" },
+            { "operatorType", OperatorId.Equals.ToString() },
+            { "value", "testCalue" }
+        });
+
+        var context = new DefaultHttpContext();
+        context.Request.Query = queryParams;
+
+        var endpointContext = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => endpointContext.HttpContext).Returns(context);
+
+        var next = A.Fake<EndpointFilterDelegate>();
+        A.CallTo(() => next(A<EndpointFilterInvocationContext>.Ignored)).Returns(ValueTask.FromResult<object?>(null));
+
+        var filter = new PolicyContentQueryParametersFilter();
+
+        // Act
+        var result = await filter.InvokeAsync(endpointContext, next);
+
+        // Assert
+        A.CallTo(() => next(A<EndpointFilterInvocationContext>.Ignored)).MustHaveHappenedOnceExactly();
+    }
+
+    [Fact]
+    public async Task InvokeAsync_InvalidQueryParameter_ThrowsException()
+    {
+        // Arrange
+        var queryParams = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            { "invalidParam", "InvalidValue" }
+        });
+
+        var context = new DefaultHttpContext();
+        context.Request.Query = queryParams;
+
+        var endpointContext = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => endpointContext.HttpContext).Returns(context);
+
+        var next = A.Fake<EndpointFilterDelegate>();
+
+        var filter = new PolicyContentQueryParametersFilter();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ControllerArgumentException>(() => filter.InvokeAsync(endpointContext, next).AsTask());
+        Assert.Contains("Invalid query parameters", exception.Message);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_InvalidEnumParameter_ThrowsException()
+    {
+        // Arrange
+        var queryParams = new QueryCollection(new Dictionary<string, Microsoft.Extensions.Primitives.StringValues>
+        {
+            { "useCase", "InvalidUseCase" },
+            { "type", "ValidType" },
+            { "policyName", "ValidPolicyName" },
+            { "operatorType", "ValidOperatorType" },
+            { "value", "ValidValue" }
+        });
+
+        var context = new DefaultHttpContext();
+        context.Request.Query = queryParams;
+
+        var endpointContext = A.Fake<EndpointFilterInvocationContext>();
+        A.CallTo(() => endpointContext.HttpContext).Returns(context);
+
+        var next = A.Fake<EndpointFilterDelegate>();
+
+        var filter = new PolicyContentQueryParametersFilter();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ControllerArgumentException>(() => filter.InvokeAsync(endpointContext, next).AsTask());
+        Assert.Contains("Invalid parameter value: [useCase: 'InvalidUseCase']", exception.Message);
+    }
+}


### PR DESCRIPTION
## Description

Added different message errors for the end point parameters. Now when one or more required parameter is missing, the message error lists the required parameters and also possible values. Helping the user to identify incorrect or missing values fast.

## Why

When requesting a policy from Get /policy-content, the client may use an incorrect parameter key, receive a 200 response, and incorrectly assume that the policy states what they intended it to state.

## Issue

[Enhance message errors](https://github.com/eclipse-tractusx/policy-hub/issues/286)

## Checklist

Please delete options that are not relevant.

- [ ] I have followed the [contributing guidelines](https://github.com/eclipse-tractusx/policy-hub/blob/main/docs/admin/dev-process/How%20to%20contribute.md)
- [ ] I have performed a self-review of my own code
- [ ] I have successfully tested my changes locally
- [ ] I have added tests that prove my changes work
- [ ] I have checked that new and existing tests pass locally with my changes
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added copyright and license headers, footers (for .md files) or files (for images)