### PR TITLE
build(1.3.2-rc.2): change bitnami image repository

### DIFF
--- a/charts/policy-hub/Chart.yaml
+++ b/charts/policy-hub/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: policy-hub
 type: application
-version: 1.3.2-rc.1
-appVersion: 1.3.2-rc.1
+version: 1.3.2-rc.2
+appVersion: 1.3.2-rc.2
 description: Helm chart for Policy Hub
 home: https://github.com/eclipse-tractusx/policy-hub
 dependencies:

--- a/charts/policy-hub/README.md
+++ b/charts/policy-hub/README.md
@@ -33,7 +33,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: policy-hub
     repository: https://eclipse-tractusx.github.io/charts/dev
-    version: 1.3.2-rc.1
+    version: 1.3.2-rc.2
 ```
 
 ## Requirements
@@ -71,7 +71,7 @@ dependencies:
 | dbConnection.schema | string | `"hub"` |  |
 | dbConnection.sslMode | string | `"Disable"` |  |
 | postgresql.enabled | bool | `true` | PostgreSQL chart configuration; default configurations: host: "policy-hub-postgresql-primary", port: 5432; Switch to enable or disable the PostgreSQL helm chart. |
-| postgresql.image | object | `{"tag":"15-debian-11"}` | Setting image tag to major to get latest minor updates |
+| postgresql.image | object | `{"registry":"docker.io","repository":"bitnamilegacy/postgresql","tag":"15-debian-11"}` | Setting image tag to major to get latest minor updates |
 | postgresql.commonLabels."app.kubernetes.io/version" | string | `"15"` |  |
 | postgresql.auth.username | string | `"hub"` | Non-root username. |
 | postgresql.auth.database | string | `"policy-hub"` | Database name. |

--- a/charts/policy-hub/values.yaml
+++ b/charts/policy-hub/values.yaml
@@ -81,6 +81,8 @@ postgresql:
   enabled: true
   # -- Setting image tag to major to get latest minor updates
   image:
+    registry: docker.io
+    repository: bitnamilegacy/postgresql
     tag: "15-debian-11"
   commonLabels:
     app.kubernetes.io/version: "15"


### PR DESCRIPTION
## Description

- change bitnami image path to legacy repository

## Why

- Bitnami now requires a paid subscription to use their images.

## Issue

Closes: #332 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
